### PR TITLE
fix: name pystemon feeder name in feeder monitor dashboard

### DIFF
--- a/bin/feeder/pystemon-feeder.py
+++ b/bin/feeder/pystemon-feeder.py
@@ -71,6 +71,7 @@ while True:
         with open(full_item_path, 'rb') as f: #.read()
             messagedata = f.read()
         path_to_send = os.path.join(pastes_directory, item_id)
+        path_to_send = 'pystemon>>' + path_to_send
 
         s = b' '.join( [ topic.encode(), path_to_send.encode(), base64.b64encode(messagedata) ] )
         socket.send(s)


### PR DESCRIPTION
Fixing [issue #94](https://github.com/ail-project/ail-framework/issues/94)
Adding a name to the pystemon feeder in addition to the default unnamed_feeder
![image](https://user-images.githubusercontent.com/7226844/115247643-42b6ba00-a127-11eb-9709-b0ea4bf5521d.png)
