### PR TITLE
fix: URLs www word to match

### DIFF
--- a/files/Urls
+++ b/files/Urls
@@ -1,3 +1,3 @@
 http
 https
-wwww
+www


### PR DESCRIPTION
There is 4 'w' chars instead of 3