### PR TITLE
Remove CIRCL NS / ZMQ from sample config file

### DIFF
--- a/configs/core.cfg.sample
+++ b/configs/core.cfg.sample
@@ -228,7 +228,7 @@ dns = 8.8.8.8
 dns = 8.8.8.8
 
 [Web]
-dns = 149.13.33.69
+dns = 8.8.8.8
 
 # Indexer configuration
 [Indexer]
@@ -247,7 +247,8 @@ maxDuplicateToPushToMISP=10
 # e.g.: tcp://127.0.0.1:5556,tcp://127.0.0.1:5557
 [ZMQ_Global]
 #address = tcp://crf.circl.lu:5556
-address = tcp://127.0.0.1:5556,tcp://crf.circl.lu:5556
+# address = tcp://127.0.0.1:5556,tcp://crf.circl.lu:5556
+address = tcp://127.0.0.1:5556
 channel = 102
 bind = tcp://127.0.0.1:5556
 


### PR DESCRIPTION
Remove some of the CIRCL specific configuration settings from the sample config file.