### PR TITLE
fix: [crawler] add exception handing for `ping_lacus`

### DIFF
--- a/bin/lib/crawlers.py
+++ b/bin/lib/crawlers.py
@@ -1795,7 +1795,11 @@ def ping_lacus():
         ping = False
         req_error = {'error': 'Lacus URL undefined', 'status_code': 400}
     else:
-        ping = lacus.is_up
+        try:
+            ping = lacus.is_up
+        except:
+            req_error = {'error': 'Failed to connect Lacus URL', 'status_code': 400}
+            ping = False
     update_lacus_connection_status(ping, req_error=req_error)
     return ping
 


### PR DESCRIPTION
## What Changed
- Fixed #173 
- Add exception handing when lacus connection check failed

## Evidence
I have verified that [the steps to reproduce #173](https://github.com/ail-project/ail-framework/issues/173) do not result in a 500 error.
<img width="1235" alt="スクリーンショット 2023-07-08 12 16 56" src="https://github.com/ail-project/ail-framework/assets/41001169/b619718a-d4a6-4745-a9c7-056736f8a0ea">

Also, after the above screen, I confirmed that setting the correct URL(**http**) worked properly.
<img width="1116" alt="スクリーンショット 2023-07-08 12 21 07" src="https://github.com/ail-project/ail-framework/assets/41001169/5f34d244-10b1-41a5-92dd-a1cdd0f99f92">

I tried to fix #173. I would appreciate it if you could review. 
Thanks again such a great tool :)

Regards,
