### PR TITLE
fix: [domain search] prevent exceptions when search domain by invalid characters

### DIFF
--- a/bin/lib/objects/Domains.py
+++ b/bin/lib/objects/Domains.py
@@ -595,21 +595,22 @@ def get_domains_up_by_filers(domain_types, date_from=None, date_to=None, tags=[]
         return None
 
 def sanitize_domain_name_to_search(name_to_search, domain_type):
+    if not name_to_search:
+        return ""
     if domain_type == 'onion':
         r_name = r'[a-z0-9\.]+'
     else:
         r_name = r'[a-zA-Z0-9-_\.]+'
     # invalid domain name
     if not re.fullmatch(r_name, name_to_search):
-        res = re.match(r_name, name_to_search)
-        return {'search': name_to_search, 'error': res.string.replace( res[0], '')}
+        return ""
     return name_to_search.replace('.', '\.')
 
 def search_domain_by_name(name_to_search, domain_types, r_pos=False):
     domains = {}
     for domain_type in domain_types:
         r_name = sanitize_domain_name_to_search(name_to_search, domain_type)
-        if not name_to_search or isinstance(r_name, dict):
+        if not r_name:
             break
         r_name = re.compile(r_name)
         for domain in get_domains_up_by_type(domain_type):


### PR DESCRIPTION
## What Changed
- Fixed #178 
- `sanitize_domain_name_to_search` returns an empty string when searched by invalid characters.

## Evidence
I have verified that [the steps to reproduce #178](https://github.com/ail-project/ail-framework/issues/178) do not result in a 500 error as follows.
<img width="1000" alt="スクリーンショット 2023-07-14 18 10 53" src="https://github.com/ail-project/ail-framework/assets/41001169/9067fdaf-a21e-4dac-81ca-8ec6484d3eea">

In addition, I also confirmed that if I entered the correct characters, the search results would appear as follows.
<img width="1000" alt="スクリーンショット 2023-07-14 18 13 02" src="https://github.com/ail-project/ail-framework/assets/41001169/9cb1482c-605e-46a5-8ab0-389762f07f4d">
<img width="1000" alt="スクリーンショット 2023-07-14 18 13 39" src="https://github.com/ail-project/ail-framework/assets/41001169/cb053de8-1445-4390-86dc-4663177f5e8f">


I tried to fix #178. I would appreciate it if you could review. 
Thank you for maintaining tool :)

Regards,