### PR TITLE
Fix IndexError in get_last_tag_from_remote Function

### DIFF
--- a/bin/packages/git_status.py
+++ b/bin/packages/git_status.py
@@ -129,17 +129,25 @@ def get_last_tag_from_local(verbose=False):
             print('{}{}{}'.format(TERMINAL_RED, process.stderr.decode(), TERMINAL_DEFAULT))
         return ''
 
-# Get last local tag
+# Get last remote tag
 def get_last_tag_from_remote(verbose=False):
     if verbose:
         print('retrieving last remote tag ...')
         #print('git ls-remote --tags')
+
     process = subprocess.run(['git', 'ls-remote', '--tags'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if process.returncode == 0:
-        res = process.stdout.split(b'\n')[-2].split(b'/')[-1].replace(b'^{}', b'').decode()
-        if verbose:
-            print(res)
-        return res
+        output_lines = process.stdout.split(b'\n')
+        if len(output_lines) > 1:
+            # Assuming we want the second-to-last line as before
+            res = output_lines[-2].split(b'/')[-1].replace(b'^{}', b'').decode()
+            if verbose:
+                print(res)
+            return res
+        else:
+            if verbose:
+                print("No tags found or insufficient output from git command.")
+            return ''
 
     else:
         if verbose:


### PR DESCRIPTION
#### Summary
This pull request addresses an `IndexError: list index out of range` that was occurring in the `get_last_tag_from_remote` function within the `git_status.py` file. The error emerged when the function attempted to access a specific index in the output of a subprocess command which sometimes returned fewer lines than expected.

#### Changes
- Added a check to verify the length of the output list before accessing the second-to-last element.
- Implemented handling for cases where the output is insufficient, thereby preventing the `IndexError`.
- Included additional verbose logging for better debugging and error tracking.

#### Impact
- These changes ensure that the function behaves as expected even when the subprocess command returns unexpected or minimal output.
- Prevents the application from crashing due to unhandled exceptions in scenarios where git tags are not as expected or absent.

#### Testing
- The function has been tested with various scenarios, including cases where the git command returns no tags, a single tag, or multiple tags. In all cases, the function now handles the output gracefully without causing an `IndexError`.

#### Full Exception when accessing Server Manager: 
```
[2024-01-01 20:24:49,550] ERROR in app: Exception on /settings [GET]
Traceback (most recent call last):
  File "/home/markus/ail-framework/AILENV/lib/python3.10/site-packages/flask/app.py", line 2190, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/markus/ail-framework/AILENV/lib/python3.10/site-packages/flask/app.py", line 1486, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/markus/ail-framework/AILENV/lib/python3.10/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/markus/ail-framework/AILENV/lib/python3.10/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/markus/ail-framework/AILENV/lib/python3.10/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
  File "/home/markus/ail-framework/var/www/./modules/Role_Manager.py", line 84, in decorated_view
    return func(*args, **kwargs)
  File "/home/markus/ail-framework/var/www/blueprints/settings_b.py", line 41, in settings_page
    git_metadata = git_status.get_git_metadata()
  File "/home/markus/ail-framework/bin/packages/git_status.py", line 157, in get_git_metadata
    dict_git['last_remote_tag'] = get_last_tag_from_remote()
  File "/home/markus/ail-framework/bin/packages/git_status.py", line 139, in get_last_tag_from_remote
    res = process.stdout.split(b'\n')[-2].split(b'/')[-1].replace(b'^{}', b'').decode()
IndexError: list index out of range

```