### PR TITLE
fix: [README] api.md link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ CIRCL organises training on how to use or extend the AIL framework. AIL training
 
 ## API
 
-The API documentation is available in [doc/README.md](doc/README.md)
+The API documentation is available in [doc/api.md](doc/api.md)
 
 ## HOWTO
 


### PR DESCRIPTION
Thank you so much for maintaining tool :)
There seems to be a typo in the README, so I fixed it. I would appreciate it if you could review.

Regards,