### PR TITLE
chg: Move yara install from var/www/update_thirdparty.sh to installing_deps.sh

### DIFF
--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -71,6 +71,21 @@ make
 sudo make install
 popd
 
+# Yara
+YARA_VERSION="4.3.0"
+mkdir yara_temp
+wget https://github.com/VirusTotal/yara/archive/v${YARA_VERSION}.zip -O yara_temp/yara.zip
+unzip yara_temp/yara.zip -d yara_temp/
+pushd yara_temp/yara-${YARA_VERSION}
+./bootstrap.sh
+./configure
+make
+sudo make install
+make check
+popd
+rm -rf yara_temp
+
+
 # ARDB #
 #test ! -d ardb/ && git clone https://github.com/ail-project/ardb.git
 #pushd ardb/

--- a/var/www/update_thirdparty.sh
+++ b/var/www/update_thirdparty.sh
@@ -77,22 +77,6 @@ unzip -qq temp/popper.zip -d temp/
 mv temp/floating-ui-${POPPER_VERSION}/dist/umd/popper.min.js ./static/js/
 mv temp/floating-ui-${POPPER_VERSION}/dist/umd/popper.min.js.map ./static/js/
 
-
-
-
-# INSTALL YARA
-YARA_VERSION="4.3.0"
-wget https://github.com/VirusTotal/yara/archive/v${YARA_VERSION}.zip -O temp/yara.zip
-unzip temp/yara.zip -d temp/
-pushd temp/yara-${YARA_VERSION}
-./bootstrap.sh
-./configure
-make
-sudo make install
-make check
-popd
-
-
 rm -rf temp
 
 mkdir -p ./static/image


### PR DESCRIPTION
The script `var/www/update_thirdparty.sh` can be run as non-sudoer user, except the installation of yara.

This commit moves the yara installation to `installing_deps.sh`, which must be run by a user with sudoer rights anyway.