### PR TITLE
fix typo `ans` to `and`

### DIFF
--- a/var/www/templates/hunter/tracker_add.html
+++ b/var/www/templates/hunter/tracker_add.html
@@ -146,7 +146,7 @@
                                                     </div>
                                                     <div class="custom-control custom-switch mt-1">
                                                         <input class="custom-control-input" type="checkbox" name="qrcode_obj" id="qrcode_obj" {% if not dict_tracker['filters'] or 'qrcode' in dict_tracker['filters'] %}checked=""{% endif %}>
-                                                        <label class="custom-control-label" for="qrcode_obj"><i class="fas fa-qrcode"></i>&nbsp;Qrcode <i class="fas fa-info-circle text-info" data-toggle="tooltip" data-placement="right" title="Qcodes Extracted from Images ans Screenshots"></i></label>
+                                                        <label class="custom-control-label" for="qrcode_obj"><i class="fas fa-qrcode"></i>&nbsp;Qrcode <i class="fas fa-info-circle text-info" data-toggle="tooltip" data-placement="right" title="Qcodes Extracted from Images and Screenshots"></i></label>
                                                     </div>
                                                     <div class="custom-control custom-switch mt-1">
                                                         <input class="custom-control-input" type="checkbox" name="ocr_obj" id="ocr_obj" {% if not dict_tracker['filters'] or 'ocr' in dict_tracker['filters'] %}checked=""{% endif %}>

--- a/var/www/templates/hunter/tracker_show.html
+++ b/var/www/templates/hunter/tracker_show.html
@@ -293,11 +293,11 @@
                                         </div>
                                         <div class="custom-control custom-switch mt-1">
                                             <input class="custom-control-input" type="checkbox" name="barcode_obj" id="barcode_obj" {% if 'barcode' in filter_obj_types or filter_obj_types|length == 0 %}checked=""{% endif %}>
-                                            <label class="custom-control-label" for="barcode_obj"><i class="fas fa-barcode"></i>&nbsp;Barcode <i class="fas fa-info-circle text-info" data-toggle="tooltip" data-placement="right" title="Qcodes Extracted from Images ans Screenshots"></i></label>
+                                            <label class="custom-control-label" for="barcode_obj"><i class="fas fa-barcode"></i>&nbsp;Barcode <i class="fas fa-info-circle text-info" data-toggle="tooltip" data-placement="right" title="Qcodes Extracted from Images and Screenshots"></i></label>
                                         </div>
                                         <div class="custom-control custom-switch mt-1">
                                             <input class="custom-control-input" type="checkbox" name="qrcode_obj" id="qrcode_obj" {% if 'qrcode' in filter_obj_types or filter_obj_types|length == 0 %}checked=""{% endif %}>
-                                            <label class="custom-control-label" for="qrcode_obj"><i class="fas fa-qrcode"></i>&nbsp;Qrcode <i class="fas fa-info-circle text-info" data-toggle="tooltip" data-placement="right" title="Qcodes Extracted from Images ans Screenshots"></i></label>
+                                            <label class="custom-control-label" for="qrcode_obj"><i class="fas fa-qrcode"></i>&nbsp;Qrcode <i class="fas fa-info-circle text-info" data-toggle="tooltip" data-placement="right" title="Qcodes Extracted from Images and Screenshots"></i></label>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
This fixes a minor typo changing  `ans` to `and`. 