### PR TITLE
fix: [Images/Screenshots] Add missing return statement in get_descrip…

### DIFF
--- a/bin/lib/objects/Images.py
+++ b/bin/lib/objects/Images.py
@@ -97,6 +97,7 @@ class Image(AbstractDaterangeObject):
             if key.startswith('desc:'):
                 model = key[5:]
                 models.append(model)
+        return models
 
     def add_description_model(self, model, description):
         self._set_field(f'desc:{model}', description)

--- a/bin/lib/objects/Screenshots.py
+++ b/bin/lib/objects/Screenshots.py
@@ -104,6 +104,7 @@ class Screenshot(AbstractObject):
             if key.startswith('desc:'):
                 model = key[5:]
                 models.append(model)
+        return models
 
     def add_description_model(self, model, description):
         self._set_field(f'desc:{model}', description)


### PR DESCRIPTION
…tion_models()

The get_description_models() method was building a list of description model names but never returning it, causing the method to implicitly return None.

This fix adds the missing return statement to both Images.py and Screenshots.py.