### PR TITLE
Improve organisation view template layout and styling

### DIFF
--- a/var/www/templates/settings/view_organisation.html
+++ b/var/www/templates/settings/view_organisation.html
@@ -13,8 +13,72 @@
 	<!-- JS -->
 	<script src="{{ url_for('static', filename='js/jquery.js')}}"></script>
     <script src="{{ url_for('static', filename='js/bootstrap4.min.js')}}"></script>
-    <script src="{{ url_for('static', filename='js/jquery.dataTables.min.js')}}"></script>
+	<script src="{{ url_for('static', filename='js/jquery.dataTables.min.js')}}"></script>
 	<script src="{{ url_for('static', filename='js/dataTables.bootstrap.min.js')}}"></script>
+	<style>
+		.org-hero {
+			background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+			color: #fff;
+			border-radius: 0.6rem;
+			box-shadow: 0 8px 24px rgba(17, 24, 39, 0.22);
+		}
+		.org-hero-subtitle {
+			color: rgba(255, 255, 255, 0.8);
+		}
+		.org-stat-card {
+			border: none;
+			border-radius: 0.6rem;
+			box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+		}
+		.org-stat-label {
+			font-size: 0.85rem;
+			text-transform: uppercase;
+			letter-spacing: .04em;
+			color: #64748b;
+			margin-bottom: .25rem;
+		}
+		.org-stat-value {
+			font-size: 1.15rem;
+			font-weight: 600;
+			color: #0f172a;
+			word-break: break-word;
+		}
+		.org-meta-card,
+		.org-users-card {
+			border: 1px solid #e5e7eb;
+			border-radius: 0.6rem;
+			box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+		}
+		.org-meta-row {
+			padding: .8rem 0;
+			border-bottom: 1px solid #eef2f7;
+		}
+		.org-meta-row:last-child {
+			border-bottom: none;
+		}
+		.org-meta-key {
+			font-weight: 600;
+			color: #334155;
+		}
+		.org-meta-value {
+			color: #0f172a;
+			word-break: break-word;
+		}
+		.org-tag {
+			font-size: .82rem;
+			margin-right: .35rem;
+			margin-bottom: .35rem;
+		}
+		.org-table-badge {
+			font-size: .76rem;
+			text-transform: uppercase;
+			letter-spacing: .03em;
+		}
+		.org-empty {
+			color: #64748b;
+			font-style: italic;
+		}
+	</style>
 
 </head>
 
@@ -29,99 +93,109 @@
 
 			<div class="col-12 col-lg-10" id="core_content">
 
-				<div class="card my-1">
-					<div class="card-header bg-dark text-white">
-						<h4 class="card-title">{{meta['name']}}</h4>
-					</div>
-					<div class="card-body">
-						<div class="container-fluid">
-							<div class="row">
-								<div class="col-12 col-lg-6">
-
-									<table class="table table-hover">
-                                        <tr>
-                                            <th style="width:30%">UUID</th>
-                                            <td>{{meta['uuid']}}</td>
-                                        </tr>
-                                        <tr>
-                                            <th>Creator</th>
-                                            <td>{{meta['creator']}}</td>
-                                        </tr>
-                                        <tr>
-                                            <th>Date</th>
-                                            <td>{{meta['date_created']}}</td>
-                                        </tr>
-                                        <tr>
-                                            <th>NB Users</th>
-                                            <td>
-                                                {{ meta['nb_users'] }}
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <th>Tags</th>
-                                            <td>
-												{% for tag in meta['tags'] %}
-													<span class="badge badge-{{ bootstrap_label[loop.index0 % 5] }} pull-left">{{ tag }}</span>
-												{% endfor %}
-											</td>
-                                        </tr>
-                                        <tr>
-                                            <th>Description</th>
-                                            <td>{{meta['descriptions']}}</td>
-                                        </tr>
-                                    </table>
-
-								</div>
-								<div class="col-12 col-lg-6">
-
-									<div class="my-4">
-{#										<a href="{{ url_for('investigations_b.delete_investigation') }}?uuid={{metadata['uuid']}}">#}
-{#											<button type="button" class="btn btn-danger">#}
-{#												<i class="fas fa-trash-alt"></i> <b>Delete</b>#}
-{#												</button>#}
-{#										</a>#}
-{#										<a href="{{ url_for('investigations_b.edit_investigation') }}?uuid={{metadata['uuid']}}">#}
-{#											<button type="button" class="btn btn-info">#}
-{#												<i class="fas fa-pencil-alt"></i> <b>Edit</b>#}
-{#											</button>#}
-{#										</a>#}
-									</div>
-
-								</div>
-							</div>
+				<div class="org-hero p-4 my-3">
+					<div class="d-flex flex-column flex-lg-row justify-content-between align-items-start align-items-lg-center">
+						<div>
+							<h3 class="mb-2">{{ meta['name'] }}</h3>
+							<p class="mb-0 org-hero-subtitle">
+								Organisation overview and member list
+							</p>
 						</div>
-
+						<div class="mt-3 mt-lg-0">
+							<span class="badge badge-light px-3 py-2">
+								UUID: {{ meta['uuid'] }}
+							</span>
+						</div>
 					</div>
 				</div>
 
-				<h3>Users</h3>
+				<div class="row">
+					<div class="col-12 col-md-4 mb-3">
+						<div class="card org-stat-card h-100">
+							<div class="card-body">
+								<div class="org-stat-label">Members</div>
+								<div class="org-stat-value">{{ meta['nb_users'] }}</div>
+							</div>
+						</div>
+					</div>
+					<div class="col-12 col-md-4 mb-3">
+						<div class="card org-stat-card h-100">
+							<div class="card-body">
+								<div class="org-stat-label">Creator</div>
+								<div class="org-stat-value">{{ meta['creator'] }}</div>
+							</div>
+						</div>
+					</div>
+					<div class="col-12 col-md-4 mb-3">
+						<div class="card org-stat-card h-100">
+							<div class="card-body">
+								<div class="org-stat-label">Created</div>
+								<div class="org-stat-value">{{ meta['date_created'] }}</div>
+							</div>
+						</div>
+					</div>
+				</div>
 
-				<table id="table_org_users" class="table table-striped border-primary">
-			  	<thead class="bg-dark text-white">
-			    	<tr>
-                        <th>User</th>
-			      	    <th>Role</th>
-                        <th></th>
-				   	</tr>
-					</thead>
-					<tbody style="font-size: 15px;">
-						{% for user in meta['users'] %}
-							<tr class="border-color: blue;">
-								<td>
-									{{ user['id'] }}
-								</td>
-								<td>
-									{{ user['role'] }}
-								</td>
-								<td class="text-right">
-{#									<a href="{{ url_for('investigations_b.unregister_investigation') }}?uuid={{ metadata['uuid']}}&type={{ object['type'] }}&subtype={{ object['subtype']}}&id={{ object['id']}}">#}
-{#										<button type="button" class="btn btn-danger"><i class="fas fa-trash-alt"></i></button>#}
-{#									</a>#}
-								</td>
-							</tr>
-						{% endfor %}
-					</tbody>
-				</table>
+				<div class="card org-meta-card my-2">
+					<div class="card-body">
+						<h5 class="mb-3">Organisation details</h5>
+						<div class="row org-meta-row">
+							<div class="col-12 col-md-3 org-meta-key">Description</div>
+							<div class="col-12 col-md-9 org-meta-value">
+								{% if meta['descriptions'] %}
+									{{ meta['descriptions'] }}
+								{% else %}
+									<span class="org-empty">No description provided.</span>
+								{% endif %}
+							</div>
+						</div>
+						<div class="row org-meta-row">
+							<div class="col-12 col-md-3 org-meta-key">Tags</div>
+							<div class="col-12 col-md-9 org-meta-value">
+								{% if meta['tags'] %}
+									{% for tag in meta['tags'] %}
+										<span class="badge badge-{{ bootstrap_label[loop.index0 % 5] }} org-tag">{{ tag }}</span>
+									{% endfor %}
+								{% else %}
+									<span class="org-empty">No tags assigned.</span>
+								{% endif %}
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div class="card org-users-card my-3">
+					<div class="card-body">
+						<div class="d-flex justify-content-between align-items-center mb-3">
+							<h5 class="mb-0">Users</h5>
+							<span class="badge badge-dark">{{ meta['nb_users'] }} total</span>
+						</div>
+						<table id="table_org_users" class="table table-striped table-hover mb-0">
+							<thead class="thead-dark">
+								<tr>
+									<th>User</th>
+									<th>Role</th>
+									<th></th>
+								</tr>
+							</thead>
+							<tbody style="font-size: 15px;">
+								{% for user in meta['users'] %}
+									<tr>
+										<td>{{ user['id'] }}</td>
+										<td>
+											<span class="badge badge-info org-table-badge">{{ user['role'] }}</span>
+										</td>
+										<td class="text-right">
+{#										<a href="{{ url_for('investigations_b.unregister_investigation') }}?uuid={{ metadata['uuid']}}&type={{ object['type'] }}&subtype={{ object['subtype']}}&id={{ object['id']}}">#}
+{#											<button type="button" class="btn btn-danger"><i class="fas fa-trash-alt"></i></button>#}
+{#										</a>#}
+										</td>
+									</tr>
+								{% endfor %}
+							</tbody>
+						</table>
+					</div>
+				</div>
 
 
 


### PR DESCRIPTION
### Motivation
- The organisation detail page was dense and hard to scan, using a simple table layout for all metadata and users.  
- Improve readability and visual hierarchy so important info (name, UUID, counts) is visible at a glance.  
- Provide clearer empty-state messaging for missing metadata and make roles/tags easier to parse.  

### Description
- Replaced the previous table-based header with a styled hero section showing the organisation name and UUID.  
- Added three summary stat cards for Members, Creator, and Created date and reorganized metadata into a card with explicit empty-state text.  
- Reworked the users area into a card containing a striped, hoverable table and rendered roles as badges for better at-a-glance recognition.  
- Added localized CSS inside the template to improve spacing, shadows, typography, tags, and badge styles while preserving existing template bindings and the DataTable initialization.  

### Testing
- Ran `git diff --check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd42d6e58832d919d2f0066ae1d9b)