### PR TITLE
Remove incremental 'Load more' behavior and related endpoint for item preview modal

### DIFF
--- a/var/www/blueprints/objects_item.py
+++ b/var/www/blueprints/objects_item.py
@@ -166,16 +166,6 @@ def item_download():  # # TODO: support post
     item = Item(item_id)
     return send_file(item.get_raw_content(), download_name=item_id, as_attachment=True)
 
-@objects_item.route("/objects/item/content/more")
-@login_required
-@login_read_only
-def item_content_more():
-    item_id = request.args.get('id', '')
-    item = Item(item_id)
-    item_content = item.get_content()
-    to_return = item_content[max_preview_modal-1:]
-    return Response(to_return, mimetype='text/plain')
-
 @objects_item.route("/objects/item/diff")
 @login_required
 @login_user

--- a/var/www/templates/modals/show_min_item.html
+++ b/var/www/templates/modals/show_min_item.html
@@ -18,10 +18,6 @@
 <script>
 // static data
 var can_change_modal_content = true;
-var alert_message = '<div class="alert alert-info alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button><strong>No more data.</strong> Full paste displayed.</div>';
-var complete_item = null;
-var char_to_display = {%if char_to_display%}{{ char_to_display }}{%else%}800{%endif%};
-var start_index = 0;
 
 // Reset modal content
 $("#modal_show_min_item").on('hidden.bs.modal', function () {
@@ -31,39 +27,7 @@ $("#modal_show_min_item").on('hidden.bs.modal', function () {
     $("#modal_show_min_item_body").append(loading_gif); // Show the loading GIF
     $("#modal_show_min_item_button_show_item").attr('href', '');
     $("#modal_show_min_item_button_show_item").hide();
-    complete_item = null;
-    start_index = 0;
 });
-
-// Update the item preview in the modal
-function update_preview() {
-    if (start_index + char_to_display > complete_item.length-1){ // end of item reached
-        var final_index = complete_item.length-1;
-        var flag_stop = true;
-    } else {
-        var final_index = start_index + char_to_display;
-    }
-
-    if (final_index != start_index){ // still have data to display
-        // Append the new content using text() and not append (XSS)
-        $("#modal_show_min_item_body").find("#paste-holder")
-                .text($("#modal_show_min_item_body")
-                .find("#paste-holder").text() + complete_item.substring(start_index+1, final_index+1));
-        start_index = final_index;
-        if (flag_stop)
-            nothing_to_display();
-    } else {
-        nothing_to_display();
-    }
-}
-
-// Update the modal when there is no more data
-function nothing_to_display() {
-    var new_content = $(alert_message).hide();
-    $("#modal_show_min_item_body").find("#panel-body").append(new_content);
-    new_content.show('fast');
-    $("#load-more-button").hide();
-}
 
 function get_html_and_update_modal(event, truemodal) {
     event.preventDefault();
@@ -79,29 +43,11 @@ function get_html_and_update_modal(event, truemodal) {
             var cleared_data = data.split("<body>")[1].split("</body>")[0];
             $("#modal_show_min_item_body").html(cleared_data);
 
-            var button = $('<button type="button" id="load-more-button" class="btn btn-outline-primary rounded-circle px-1 py-0" data-url="' + $(modal).attr('data-path') +'" data-toggle="tooltip" data-placement="bottom" title="Load more content"><i class="fas fa-arrow-circle-down mt-1"></i></button>');
-            button.tooltip(button);
-            $("#container-show-more").append(button);
-
             $("#modal_show_min_item_button_show_item").attr('href', '{{ url_for('objects_item.showItem')  }}?id=' + $(modal).attr('data-path'));
             $("#modal_show_min_item_button_show_item").show('fast');
             $("#loading-gif-modal").css("visibility", "hidden"); // Hide the loading GIF
-            if ($("[data-initsize]").attr('data-initsize') < char_to_display) { // All the content is displayed
-                nothing_to_display();
-            }
             // collapse decoded
             $('#collapseDecoded').collapse('hide');
-            // On click, donwload all item's content
-            $("#load-more-button").on("click", function (event) {
-                if (complete_item == null) { //Donwload only once
-                    $.get("{{ url_for('objects_item.item_content_more') }}"+"?id="+$(modal).attr('data-path'), function(data, status){
-                        complete_item = data;
-                        update_preview();
-                    });
-                } else {
-                    update_preview();
-                }
-            });
     });
 }
 

--- a/var/www/templates/objects/item/show_item_min.html
+++ b/var/www/templates/objects/item/show_item_min.html
@@ -287,10 +287,6 @@
   </script>
 {% endif %}
 
-  <div id="container-show-more" class="text-center">
-
-  </div>
-
   </html>
 
 </body>


### PR DESCRIPTION
### Motivation
- Simplify the item preview modal by removing the incremental "load more" functionality and its backend endpoint to reduce complexity and surface area for bugs/XSS and to always render the full preview content returned by the server.

### Description
- Remove the backend route and handler for `"/objects/item/content/more"` and its associated logic that served additional item content fragments.
- Eliminate incremental-loading JS state and helper functions (`alert_message`, `complete_item`, `char_to_display`, `start_index`, `update_preview`, `nothing_to_display`) and the `#load-more-button` click handling from `show_min_item.html` so the modal simply injects the preview body returned by the preview endpoint.
- Remove the `#container-show-more` placeholder div from `show_item_min.html` and the dynamic creation of the load-more button in the modal script.
- Keep modal behavior to fetch `objects_item.item_preview`, inject the cleaned `<body>` content, show the "Show Item" button, and hide the loading GIF.

### Testing
- Ran the project's automated backend unit tests; all tests passed.
- Ran frontend linting/static checks; no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65e923298832dbc3cf023315e6de3)