### PR TITLE
Improve investigation add/edit form usability and visual consistency

### DIFF
--- a/var/www/templates/investigations/add_investigation.html
+++ b/var/www/templates/investigations/add_investigation.html
@@ -53,6 +53,22 @@
 			border: 1px dashed #adb5bd;
 			background: #fcfcfd;
 		}
+		.status-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			grid-gap: 0.75rem;
+		}
+		.status-chip {
+			background: #f8f9fc;
+			border: 1px solid #e9ecef;
+			border-radius: 0.5rem;
+			padding: 0.75rem;
+		}
+		.section-divider {
+			border-top: 1px solid rgba(0, 0, 0, 0.06);
+			margin-top: 1rem;
+			padding-top: 1rem;
+		}
 		.sticky-panel {
 			position: sticky;
 			top: 1rem;
@@ -126,6 +142,8 @@
 														<small class="text-muted form-hint">Use a short and specific title for easier search and collaboration.</small>
 													</div>
 
+													<div class="section-divider"></div>
+
 													<div class="form-group mb-0">
 														<label for="investigation_description" class="font-weight-bold mb-1">Description</label>
 														<div class="input-group">
@@ -144,6 +162,16 @@
 													<p class="mb-0 text-muted">Track investigation progress and set the investigation date.</p>
 												</div>
 												<div class="card-body">
+													<div class="status-grid mb-3">
+														<div class="status-chip">
+															<div class="small text-uppercase text-muted">Status</div>
+															<div class="font-weight-bold"><i class="fas fa-stream text-info mr-1"></i>Workflow stage</div>
+														</div>
+														<div class="status-chip">
+															<div class="small text-uppercase text-muted">Date</div>
+															<div class="font-weight-bold"><i class="far fa-calendar-alt text-secondary mr-1"></i>Case timeline</div>
+														</div>
+													</div>
 													<div class="form-group">
 													 <label for="analysis" class="font-weight-bold mb-1">Analysis status
 														 <span id="analysis_idInfoPopover" class="fas fa-info-circle" data-toggle="popover" data-trigger="hover"></span>
@@ -170,6 +198,8 @@
 														 <option value="2">Completed</option>
 													 </select>
 													</div>
+
+													<div class="section-divider"></div>
 
 													<div class="form-group mb-0">
 														<label for="ivestigation-date-input" class="font-weight-bold mb-1">Investigation date <span class="text-danger">*</span></label>
@@ -216,6 +246,10 @@
 														{% endif %}
 													</select>
 													<small class="text-muted d-block mt-2">Global shares this investigation with all eligible users; My Organisation restricts visibility to your organisation.</small>
+													<div class="alert alert-light border mt-3 mb-0 small">
+														<i class="fas fa-shield-alt text-success mr-1"></i>
+														Choose <strong>My Organisation</strong> for internal-only investigations.
+													</div>
 												</div>
 											</div>
 
@@ -234,7 +268,10 @@
 									</div>
 
 
-									<div class="d-flex justify-content-end mt-2 mb-4">
+									<div class="d-flex justify-content-between flex-wrap mt-2 mb-4">
+									<a href="{{ url_for('investigations_b.investigations_dashboard') }}" class="btn btn-outline-secondary mb-2 mb-sm-0">
+										<i class="fas fa-arrow-left"></i> Back to investigations
+									</a>
 									<button class="btn btn-primary px-4 py-2">
 										{% if edit %}
 											<i class="fas fa-pencil-alt"></i> Edit Investigation


### PR DESCRIPTION
### Motivation
- Make the investigation `add`/`edit` form more user friendly and visually consistent with the `/retro_hunt/add` template to help users scan and complete the form faster.
- Improve clarity of the status/timeline and publishing options so creators can set visibility and dates without confusion.
- Provide an explicit navigation affordance to quickly return to the investigations dashboard.

### Description
- Added CSS and layout primitives (`status-grid`, `status-chip`, `section-divider`) in `var/www/templates/investigations/add_investigation.html` to create compact, reusable UI blocks. 
- Added an at-a-glance status/timeline grid above the `Analysis status` and `Investigation date` fields and inserted `section-divider` separators between logical form groups for improved readability. 
- Enhanced the publishing panel with an inline visibility guidance alert and changed the action area to include a `Back to investigations` button that links to `investigations_b.investigations_dashboard`. 
- Adjusted the submit/button container layout to support the new back-navigation control while preserving the primary action.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c71ec3fc832dbc9f9bb4b854556c)