### PR TITLE
Improve investigation link affordance in investigations dashboard

### DIFF
--- a/var/www/templates/investigations/investigations.html
+++ b/var/www/templates/investigations/investigations.html
@@ -127,26 +127,40 @@
         }
 
         .investigation-link {
-            color: inherit;
+            color: #1c4fc8;
             display: block;
             text-decoration: none;
             border-radius: .5rem;
-            padding: .15rem .25rem;
+            padding: .2rem .3rem;
             margin: -.15rem -.25rem;
-            transition: background-color 0.2s ease;
+            border: 1px solid transparent;
+            transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
         }
 
         .investigation-link:hover,
         .investigation-link:focus {
-            color: inherit;
+            color: #143a93;
             text-decoration: none;
-            background-color: #f6f9ff;
+            background-color: #f0f5ff;
+            border-color: #c9d9fb;
+            box-shadow: 0 0.2rem 0.45rem rgba(20, 58, 147, 0.12);
         }
 
         .investigation-name {
             font-weight: 600;
-            color: #1f2d3d;
+            color: inherit;
             word-break: break-word;
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 2px;
+        }
+
+        .investigation-link-hint {
+            display: inline-block;
+            margin-top: .35rem;
+            font-size: 0.78rem;
+            color: #3759b8;
+            font-weight: 600;
         }
 
         .investigation-tags {
@@ -313,6 +327,9 @@
                                         <td>
                                             <a class="investigation-link" href="{{ url_for('investigations_b.show_investigation') }}?uuid={{ dict_investigation['uuid'] }}">
                                                 <span class="investigation-name">{{ dict_investigation['info']}}</span>
+                                                <span class="investigation-link-hint">
+                                                    Open investigation <i class="fas fa-external-link-alt fa-xs ml-1" aria-hidden="true"></i>
+                                                </span>
                                                 <div class="investigation-tags">
                                                     {% for tag in dict_investigation['tags'] %}
                                                         <span class="badge badge-{{ bootstrap_label[loop.index0 % 5] }}">{{ tag }}</span>
@@ -369,6 +386,9 @@
                                         <td>
                                             <a class="investigation-link" href="{{ url_for('investigations_b.show_investigation') }}?uuid={{ dict_investigation['uuid'] }}">
                                                 <span class="investigation-name">{{ dict_investigation['info']}}</span>
+                                                <span class="investigation-link-hint">
+                                                    Open investigation <i class="fas fa-external-link-alt fa-xs ml-1" aria-hidden="true"></i>
+                                                </span>
                                                 <div class="investigation-tags">
                                                     {% for tag in dict_investigation['tags'] %}
                                                         <span class="badge badge-{{ bootstrap_label[loop.index0 % 5] }}">{{ tag }}</span>


### PR DESCRIPTION
### Motivation
- The investigation titles were rendered in plain black which made it hard to tell they were clickable links at a glance. 
- Improve discoverability and clickability of investigations in both the "My Organisation" and "Global Investigations" tables.

### Description
- Updated styles in `var/www/templates/investigations/investigations.html` to make `.investigation-link` use a prominent blue color, a transparent border, and a subtle hover background, border color, and shadow to look more like an actionable item. 
- Made `.investigation-name` inherit the link color and added an underline to reinforce clickability, and slightly adjusted link padding for balance. 
- Added an inline hint element `.investigation-link-hint` that displays the text `Open investigation` with an external-link icon under each investigation title in both organisation and global tables.

### Testing
- No automated tests were run for this change because it is a UI-only template/CSS update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f4ddb0cc832d977a50e1da602fe6)