### PR TITLE
Improve investigations sidebar organization

### DIFF
--- a/var/www/templates/sidebars/sidebar_investigations.html
+++ b/var/www/templates/sidebars/sidebar_investigations.html
@@ -1,21 +1,27 @@
       <div class="col-12 col-lg-2 p-0 bg-light border-right" id="side_menu">
 
-      	<button type="button" class="btn btn-outline-secondary mt-1 ml-3" onclick="toggle_sidebar()">
+      	<button type="button" class="btn btn-outline-secondary mt-1 ml-3" onclick="toggle_sidebar();">
           <i class="fas fa-align-left"></i>
       	  <span>Toggle Sidebar</span>
       	</button>
 
       	<nav class="navbar navbar-expand navbar-light bg-light flex-md-column flex-row align-items-start py-2" id="nav_menu">
-          <h5 class="d-flex text-muted w-100">
+          <h5 class="d-flex text-muted w-100" id="nav_investigations">
       		  <span>Investigations</span>
       		</h5>
-          <ul class="nav flex-md-column flex-row navbar-nav justify-content-between w-100 mb-4">
+          <ul class="nav flex-md-column flex-row navbar-nav justify-content-between w-100">
       	    <li class="nav-item">
       	      <a class="nav-link" href="{{url_for('investigations_b.investigations_dashboard')}}" id="nav_investigation_dashboard">
                 <i class="fas fa-microscope"></i>
       	        <span>Investigations</span>
       	      </a>
       	    </li>
+          </ul>
+
+          <h5 class="d-flex text-muted w-100 py-2" id="nav_manage_investigations">
+              <span>Manage</span>
+          </h5>
+          <ul class="nav flex-md-column flex-row navbar-nav justify-content-between w-100">
       	    <li class="nav-item">
       	      <a class="nav-link" href="{{url_for('investigations_b.add_investigation')}}" id="nav_add_investigation">
       	        <i class="fas fa-plus"></i>


### PR DESCRIPTION
### Motivation
- Make the `Investigations` sidebar markup consistent with other sidebars by introducing explicit section IDs and clearer grouping. 
- Improve visual structure and maintainability without changing existing routes or JavaScript behavior.

### Description
- Add `id="nav_investigations"` to the main `Investigations` heading and `id="nav_manage_investigations"` to the new `Manage` heading. 
- Split the single link block into two distinct sections (`Investigations` and `Manage`) by closing the first `ul` and inserting a new heading and `ul` for management links. 
- Remove the extra bottom margin class and standardize the toggle handler to `onclick="toggle_sidebar();"` for consistency with other sidebar templates. 

### Testing
- Verified the template diff for `var/www/templates/sidebars/sidebar_investigations.html` to confirm the expected markup changes. 
- Confirmed the repository working tree shows the updated template file. 
- No automated unit tests were run for templates; the change is limited to markup and preserves existing link targets and toggle behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fab320c4832d9a87bba4184ba121)