### PR TITLE
Add FlowIntel integration to user settings (backend and UI)

### DIFF
--- a/bin/lib/ail_config.py
+++ b/bin/lib/ail_config.py
@@ -48,7 +48,7 @@ def delete_user_set_config(user_id, name):
 
 # OBJECT
 def get_user_obj_names():
-    return {'misp'}
+    return {'misp', 'flowintel'}
 
 def _get_user_obj_config(user_id, obj_name, field_name):
     field = f'{obj_name}:{field_name}'
@@ -268,7 +268,107 @@ def api_delete_user_misp(user_id, data):
 
 ## --MISP-- ##
 
+#### FLOWINTEL ####
+
+class UserConfigFlowIntel(AbstractUserConfigObject):
+    def __init__(self, uuidv5, user_id):
+        super().__init__(name='flowintel', fields_names={'url', 'api_key', 'ssl', 'description'}, uuidv5=uuidv5, user_id=user_id)
+
+    def get_url(self):
+        return self.get_config_field('url')
+
+    def get_description(self):
+        return self.get_config_field('description')
+
+    def get_meta(self):
+        return {'uuid': self.uuid,
+                'url': self.get_url(),
+                'api_key': self.get_config_field('api_key'),
+                'ssl': self.get_config_field('ssl') == 'True',
+                'description': self.get_description()}
 
 
+def get_user_config_flowintels(user_id):
+    meta = []
+    for uuidv5 in get_user_config_objs('flowintel', user_id):
+        flowintel_conf = UserConfigFlowIntel(uuidv5, user_id)
+        meta.append(flowintel_conf.get_meta())
+    return meta
 
+def create_user_config_flowintel(user_id, url, api_key, ssl, description):
+    uuidv5 = generate_uuid5(f'{url}|{api_key}')
+    flowintel_conf = UserConfigFlowIntel(uuidv5, user_id)
+    if flowintel_conf.exists():
+        return uuidv5
+    else:
+        ssl = bool(ssl)
+        flowintel_conf.set_config({'url': url, 'api_key': api_key, 'ssl': str(ssl), 'description': description})
+        return uuidv5
 
+def edit_user_config_flowintel(uuidv5, user_id, url, api_key, ssl, description):
+    new_uuidv5 = generate_uuid5(f'{url}|{api_key}')
+    if new_uuidv5 != uuidv5:
+        UserConfigFlowIntel(uuidv5, user_id).delete()
+        return create_user_config_flowintel(user_id, url, api_key, ssl, description)
+    else:
+        flowintel_conf = UserConfigFlowIntel(new_uuidv5, user_id)
+        flowintel_conf.set_config_field('ssl', str(ssl))
+        flowintel_conf.set_config_field('description', description)
+        return new_uuidv5
+
+## ## API ## ##
+
+def api_get_user_flowintels(user_id, uuidv5):
+    flowintel_conf = UserConfigFlowIntel(uuidv5, user_id)
+    if not flowintel_conf.exists():
+        return {'status': 'error', 'reason': 'Unknown uuid'}, 404
+    else:
+        return flowintel_conf.get_meta(), 200
+
+def api_edit_user_flowintel(user_id, data):
+    conf_uuid = data.get('uuid')
+    url = data.get('url')
+    api_key = data.get('api_key')
+    flowintel_ssl = data.get('ssl')
+    if flowintel_ssl:
+        flowintel_ssl = True
+    else:
+        flowintel_ssl = False
+    description = data.get('description')
+    if description:
+        if len(description) > 2000:
+            description = description[:2000]
+
+    if not url:
+        return {'status': 'error', 'reason': 'missing flowintel url'}, 400
+    if not api_key:
+        return {'status': 'error', 'reason': 'missing flowintel api key'}, 400
+    if len(api_key) != 60 or not api_key.isalnum():
+        return {'status': 'error', 'reason': 'invalid flowintel api key'}, 400
+
+    if len(url) > 2000:
+        url = url[:2000]
+
+    if not ail_users.exists_user(user_id):
+        return {'status': 'error', 'reason': 'Unknown user'}, 400
+
+    if conf_uuid:
+        if not is_valid_uuid_v5(conf_uuid):
+            return {'status': 'error', 'reason': 'Unknown user'}, 400
+        else:
+            return edit_user_config_flowintel(conf_uuid, user_id, url, api_key, flowintel_ssl, description), 200
+    else:
+        return create_user_config_flowintel(user_id, url, api_key, flowintel_ssl, description), 200
+
+def api_delete_user_flowintel(user_id, data):
+    conf_uuid = data.get('uuid')
+    if not is_valid_uuid_v5(conf_uuid):
+        return {'status': 'error', 'reason': 'Unknown user'}, 400
+    else:
+        flowintel = UserConfigFlowIntel(conf_uuid, user_id)
+        flowintel.delete()
+        return conf_uuid, 200
+
+## -- API -- ##
+
+## --FLOWINTEL-- ##

--- a/var/www/blueprints/settings_b.py
+++ b/var/www/blueprints/settings_b.py
@@ -81,6 +81,7 @@ def user_profile():
     global_2fa = ail_users.is_2fa_enabled()
     return render_template("user_profile.html", meta=meta, global_2fa=global_2fa,
                            misps=ail_config.get_user_config_misps(user_id),
+                           flowintels=ail_config.get_user_config_flowintels(user_id),
                            rulezet_error=request.args.get('rulezet_error'),
                            rulezet_success=request.args.get('rulezet_success'),
                            acl_admin=acl_admin)
@@ -267,6 +268,58 @@ def delete_misp():
     return redirect(url_for('settings_b.user_profile'))
 
 ## --USER MISP-- ##
+
+#### USER FLOWINTEL ####
+
+@settings_b.route("/settings/user/edit_flowintel", methods=['GET'])
+@login_required
+@login_user
+def edit_flowintel():
+    acl_admin = current_user.is_in_role('admin')
+    conf_uuid = request.args.get('uuid')
+    if conf_uuid:
+        user_id = current_user.get_user_id()
+        meta = ail_config.api_get_user_flowintels(user_id, conf_uuid)[0]
+    else:
+        meta = {}
+    return render_template("flowintel_add_instance.html", meta=meta,
+                           acl_admin=acl_admin)
+
+@settings_b.route("/settings/user/edit_flowintel_post", methods=['POST'])
+@login_required
+@login_user
+def edit_flowintel_post():
+    user_id = current_user.get_user_id()
+    uuidv5 = request.form.get('uuid')
+    url = request.form.get('flowintel_url')
+    api_key = request.form.get('api_key')
+    description = request.form.get('description')
+    flowintel_ssl = request.form.get('flowintel_verify_ssl')
+    if flowintel_ssl:
+        flowintel_ssl = True
+    else:
+        flowintel_ssl = False
+
+    data = {'url': url, 'api_key': api_key, 'ssl': flowintel_ssl, 'description': description}
+    if uuidv5:
+        data['uuid'] = uuidv5
+    r = ail_config.api_edit_user_flowintel(user_id, data)
+    if r[1] != 200:
+        return create_json_response(r[0], r[1])
+    else:
+        return redirect(url_for('settings_b.user_profile'))
+
+@settings_b.route("/settings/user/flowintel/delete", methods=['GET'])
+@login_required
+@login_user
+def delete_flowintel():
+    conf_uuid = request.args.get('uuid')
+    if conf_uuid:
+        user_id = current_user.get_user_id()
+        ail_config.api_delete_user_flowintel(user_id, {'uuid': conf_uuid})
+    return redirect(url_for('settings_b.user_profile'))
+
+## --USER FLOWINTEL-- ##
 
 #### USER RULEZET ####
 

--- a/var/www/templates/settings/flowintel_add_instance.html
+++ b/var/www/templates/settings/flowintel_add_instance.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>FlowIntel Settings - AIL</title>
+	<link rel="icon" href="{{ url_for('static', filename='image/ail-icon.png') }}">
+
+  <!-- Core CSS -->
+	<link href="{{ url_for('static', filename='css/bootstrap4.min.css') }}" rel="stylesheet">
+	<link href="{{ url_for('static', filename='css/font-awesome.min.css') }}" rel="stylesheet">
+	<link href="{{ url_for('static', filename='css/dataTables.bootstrap.min.css') }}" rel="stylesheet">
+
+  <!-- JS -->
+	<script src="{{ url_for('static', filename='js/jquery.js')}}"></script>
+	<script src="{{ url_for('static', filename='js/popper.min.js')}}"></script>
+	<script src="{{ url_for('static', filename='js/bootstrap4.min.js')}}"></script>
+	<script src="{{ url_for('static', filename='js/jquery.dataTables.min.js')}}"></script>
+	<script src="{{ url_for('static', filename='js/dataTables.bootstrap.min.js')}}"></script>
+
+</head>
+<body>
+
+{% include 'nav_bar.html' %}
+	<div class="container-fluid">
+        <div class="row">
+            {% include 'settings/menu_sidebar.html' %}
+            <div class="col-12 col-lg-10" id="core_content">
+
+
+                <form class="form-signin" action="{{ url_for('settings_b.edit_flowintel_post')}}" autocomplete="off" method="post">
+
+                    <h1 class="h3 my-2 text-center text-secondary">{% if meta %}Edit{% else %}ADD{% endif %} FlowIntel API</h1>
+                    <label  class="mt-3" for="flowintel_url">URL:</label>
+                    {% if meta['url'] %}
+                        <input type="text" name="uuid" hidden="" value="{{ meta['uuid'] }}">
+                        <input type="text" id="flowintel_url" name="flowintel_url" class="form-control" placeholder="URL" value="{{ meta['url'] }}" aria-describedby="flowintel_url" required>
+                    {% else %}
+                        <input type="text" id="flowintel_url" name="flowintel_url" class="form-control" placeholder="URL" aria-describedby="flowintel_url" required>
+                    {% endif %}
+
+                    <label  class="mt-3" for="api_key">API Key:</label>
+                    {% if meta['api_key'] %}
+                        <input type="text" id="api_key" name="api_key" class="form-control" placeholder="API KEY" value="{{ meta['api_key'] }}" aria-describedby="api_key" minlength="60" maxlength="60" pattern="[A-Za-z0-9]{60}" title="FlowIntel API key must contain exactly 60 alphanumeric characters." required>
+                    {% else %}
+                        <input type="text" id="api_key" name="api_key" class="form-control" placeholder="API KEY" aria-describedby="api_key" minlength="60" maxlength="60" pattern="[A-Za-z0-9]{60}" title="FlowIntel API key must contain exactly 60 alphanumeric characters." required>
+                    {% endif %}
+
+                    <label  class="mt-3" for="description">Description:</label>
+                    {% if meta['api_key'] %}
+                        <input type="text" id="description" name="description" class="form-control" placeholder="DESCRIPTION" value="{% if meta['description'] %}{{ meta['description'] }}{% endif %}" aria-describedby="description">
+                    {% else %}
+                        <input type="text" id="description" name="description" class="form-control" placeholder="DESCRIPTION" aria-describedby="description">
+                    {% endif %}
+
+                    <div class="custom-control custom-switch mt-4 mb-3">
+  				        <input type="checkbox" class="custom-control-input" id="flowintel_verify_ssl" name="flowintel_verify_ssl" {% if meta %}{% if meta['ssl'] %}checked{% endif %}{% else %}checked{% endif %}>
+  				        <label class="custom-control-label" for="flowintel_verify_ssl">Verify SSL Certificate</label>
+				    </div>
+
+                    <button class="btn btn-lg btn-primary btn-block mt-3" type="submit">Submit</button>
+                </form>
+
+    	    </div>
+		</div>
+	</div>
+</body>
+
+<script>
+$(document).ready(function(){
+  $("#page-options").addClass("active");
+  $("#nav_edit_profile").addClass("active");
+  $("#nav_my_profile").removeClass("text-muted");
+} );
+
+function toggle_sidebar(){
+	if($('#nav_menu').is(':visible')){
+		$('#nav_menu').hide();
+		$('#side_menu').removeClass('border-right')
+		$('#side_menu').removeClass('col-lg-2')
+		$('#core_content').removeClass('col-lg-10')
+	}else{
+		$('#nav_menu').show();
+		$('#side_menu').addClass('border-right')
+		$('#side_menu').addClass('col-lg-2')
+		$('#core_content').addClass('col-lg-10')
+	}
+}
+</script>
+
+</html>

--- a/var/www/templates/settings/user_profile.html
+++ b/var/www/templates/settings/user_profile.html
@@ -430,6 +430,82 @@
                             </div>
                         </div>
 
+                        <div class="card my-2 shadow-sm">
+                            <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                                <h3 class="section-title">FlowIntel Integrations</h3>
+                                <a href="{{ url_for('settings_b.edit_flowintel') }}" class="btn btn-primary btn-sm">
+                                    <i class="fa-solid fa-plus"></i> Add FlowIntel Account
+                                </a>
+                            </div>
+                            <div class="card-body">
+                                <div class="card">
+                                    <div class="card-body">
+                                        <h3 class="card-title text-center"><img src="{{ url_for('static', filename='image/flowintel-logo.png')}}" alt="FlowIntel" class="misp-logo"></h3>
+
+                                        {% if flowintels|length == 0 %}
+                                            <div class="misp-empty-state">
+                                                <i class="fas fa-plug fa-lg mb-2"></i>
+                                                <p class="mb-2">No FlowIntel integrations configured yet.</p>
+                                                <a href="{{ url_for('settings_b.edit_flowintel') }}" class="btn btn-primary btn-sm">
+                                                    Add your first FlowIntel account
+                                                </a>
+                                            </div>
+                                        {% else %}
+                                        <div class="table-responsive">
+                                        <table id="table_flowintel_config" class="table table-striped table-hover border-primary misp-table">
+                                            <thead class="bg-dark text-white">
+                                            <tr>
+                                                <th>Description</th>
+                                                <th>url</th>
+                                                <th>api key</th>
+                                                <th>verify cert</th>
+                                                <th></th>
+                                            </tr>
+                                            </thead>
+                                            <tbody style="font-size: 15px;">
+                                            {% for flowintel in flowintels %}
+                                                <tr class="border-color: blue;">
+                                                    <td>
+                                                        {% if flowintel['description'] %}
+                                                            {{ flowintel['description'] }}
+                                                        {% endif %}
+                                                    </td>
+                                                    <td>{{ flowintel['url'] }}</td>
+                                                    <td>
+                                                        {% if flowintel['api_key'] %}
+                                                            {{ flowintel['api_key'][0:4] }}*********************************{{ flowintel['api_key'][-4:] }}
+                                                        {% endif %}
+                                                    </td>
+                                                    <td>
+                                                        {% if flowintel['ssl'] %}
+                                                            <i class="fa-solid fa-check"></i>
+                                                        {% else %}
+                                                            <i class="fa-solid fa-xmark"></i>
+                                                        {% endif %}
+                                                    </td>
+                                                    <td>
+                                                        <a href="{{ url_for('settings_b.edit_flowintel') }}?uuid={{ flowintel['uuid'] }}">
+                                                            <button type="button" class="btn btn-outline-info misp-action-btn" title="Edit FlowIntel connection">
+                                                                <i class="fas fa-pencil-alt"></i>
+                                                            </button>
+                                                        </a>
+                                                        <a href="{{ url_for('settings_b.delete_flowintel') }}?uuid={{ flowintel['uuid'] }}" onclick="return confirm('Delete this FlowIntel integration?');">
+                                                            <button type="button" class="btn btn-outline-danger misp-action-btn" title="Delete FlowIntel connection">
+                                                                <i class="fa-solid fa-trash-can"></i>
+                                                            </button>
+                                                        </a>
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                            </tbody>
+                                        </table>
+                                        </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
 
 					</div>
 				</div>
@@ -455,6 +531,13 @@ $(document).ready(function(){
 
     if ($('#table_misp_config').length) {
         $('#table_misp_config').DataTable({
+            "aLengthMenu": [[5, 10, 15, -1], [5, 10, 15, "All"]],
+            "iDisplayLength": 10,
+            "order": [[ 2, "desc" ]]
+        });
+    }
+    if ($('#table_flowintel_config').length) {
+        $('#table_flowintel_config').DataTable({
             "aLengthMenu": [[5, 10, 15, -1], [5, 10, 15, "All"]],
             "iDisplayLength": 10,
             "order": [[ 2, "desc" ]]


### PR DESCRIPTION
### Motivation

- Add support for configuring FlowIntel API instances per user so users can store URL, API key, SSL verification and description for integrations.

### Description

- Add `flowintel` to the user-config object types and implement `UserConfigFlowIntel` with CRUD helpers and API endpoints in `bin/lib/ail_config.py` to create, edit, list and delete FlowIntel instances.
- Wire the FlowIntel endpoints into the settings blueprint by adding routes `edit_flowintel`, `edit_flowintel_post`, and `delete_flowintel` and include FlowIntel data when rendering the profile in `var/www/blueprints/settings_b.py`.
- Add a new template `var/www/templates/settings/flowintel_add_instance.html` for adding/editing FlowIntel instances and extend `var/www/templates/settings/user_profile.html` to show a list of configured FlowIntel integrations with masked API keys and action buttons.
- Initialize a DataTable for the FlowIntel configuration table in the profile page and add form validation constraints in the new template for the API key length/format.

### Testing

- No automated tests were added for this change and no test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb5c39148832d8fbef6a99165ee24)