### PR TITLE
Introduce geo_engine for GEO observations and add AbstractObject GEO methods with tests

### DIFF
--- a/bin/lib/geo_engine.py
+++ b/bin/lib/geo_engine.py
@@ -1,0 +1,117 @@
+# -*-coding:UTF-8 -*
+"""
+GEO engine helpers for AIL objects.
+"""
+
+import os
+import sys
+
+sys.path.append(os.environ['AIL_BIN'])
+
+from lib.ConfigLoader import ConfigLoader
+from lib import ail_core
+
+config_loader = ConfigLoader()
+r_geo = config_loader.get_db_conn("Kvrocks_GEO")
+config_loader = None
+
+
+def create_geo_id():
+    """Create a compact GEO identifier."""
+    return ail_core.generate_uuid().replace("-", "")
+
+
+def add_geo_to_object(obj_gid, obj_type, lon, lat, probability=None, geo_id=None):
+    """Create a GEO observation point for an object and index it."""
+    if not geo_id:
+        geo_id = create_geo_id()
+
+    geo_key = f'g:{geo_id}'
+    r_geo.hset(geo_key, 'o', obj_gid)
+    if probability is not None:
+        r_geo.hset(geo_key, 'p', probability)
+
+    obj_geo_key = f'o:{obj_gid}'
+    obj_type_geo_key = f'objs:{obj_type}'
+    r_geo.geoadd(obj_geo_key, [lon, lat, geo_id])
+    r_geo.geoadd(obj_type_geo_key, [lon, lat, geo_id])
+    return geo_id
+
+
+def remove_geo_from_object(obj_gid, obj_type, geo_id):
+    """Remove one GEO observation point from all indexes and metadata."""
+    removed_object = r_geo.zrem(f'o:{obj_gid}', geo_id)
+    removed_obj_type = r_geo.zrem(f'objs:{obj_type}', geo_id)
+    removed_meta = r_geo.delete(f'g:{geo_id}')
+    return bool(removed_object or removed_obj_type or removed_meta)
+
+
+def object_has_geo(obj_gid):
+    """Return whether an object has at least one GEO observation point."""
+    return r_geo.zcard(f'o:{obj_gid}') > 0
+
+
+def delete_all_geo_from_object(obj_gid, obj_type):
+    """Delete all GEO observation points attached to an object."""
+    obj_key = f'o:{obj_gid}'
+    type_key = f'objs:{obj_type}'
+    geo_ids = r_geo.zrange(obj_key, 0, -1)
+    if not geo_ids:
+        return 0
+
+    r_geo.zrem(type_key, *geo_ids)
+    meta_keys = [f'g:{geo_id}' for geo_id in geo_ids]
+    r_geo.delete(*meta_keys)
+    r_geo.delete(obj_key)
+    return len(geo_ids)
+
+
+def get_geo_probability(geo_id):
+    """Return the stored GEO probability if present."""
+    return r_geo.hget(f'g:{geo_id}', 'p')
+
+
+def get_geo_object_gid(geo_id):
+    """Return the object global id attached to one GEO id."""
+    return r_geo.hget(f'g:{geo_id}', 'o')
+
+
+def get_geo_position(obj_gid, geo_id):
+    """Return one GEO position from the canonical object GEO key."""
+    return r_geo.geopos(f'o:{obj_gid}', geo_id)
+
+
+def get_all_geo_positions(obj_gid):
+    """Return all GEO positions for one object."""
+    obj_key = f'o:{obj_gid}'
+    geo_ids = r_geo.zrange(obj_key, 0, -1)
+    if not geo_ids:
+        return []
+
+    positions = r_geo.geopos(obj_key, *geo_ids)
+    geos = []
+    for geo_id, pos in zip(geo_ids, positions):
+        geos.append({'geo_id': geo_id, 'position': pos})
+    return geos
+
+
+def get_object_nb_geos(obj_gid):
+    """Return the number of GEO points attached to one object."""
+    return r_geo.zcard(f'o:{obj_gid}')
+
+
+def yield_objects_type_geos(obj_type):
+    """Yield all GEO observations for one object type."""
+    type_key = f'objs:{obj_type}'
+    geo_ids = r_geo.zrange(type_key, 0, -1)
+    if not geo_ids:
+        return
+
+    positions = r_geo.geopos(type_key, *geo_ids)
+    for geo_id, pos in zip(geo_ids, positions):
+        yield {
+            'geo_id': geo_id,
+            'obj_gid': r_geo.hget(f'g:{geo_id}', 'o'),
+            'position': pos,
+            'probability': r_geo.hget(f'g:{geo_id}', 'p')
+        }

--- a/bin/lib/objects/abstract_object.py
+++ b/bin/lib/objects/abstract_object.py
@@ -29,6 +29,7 @@ from lib.Investigations import is_object_investigated, get_obj_investigations, d
 from lib.relationships_engine import get_obj_nb_relationships, get_obj_relationships, add_obj_relationship
 from lib.Language import get_obj_languages, add_obj_language, remove_obj_language, detect_obj_language, get_obj_language_stats, get_obj_translation, set_obj_translation, delete_obj_translation, get_obj_main_language, delete_obj_language, get_container_language_objs
 from lib.Tracker import is_obj_tracked, get_obj_trackers, delete_obj_trackers, is_obj_retro_hunted, get_obj_retro_hunts, delete_obj_retro_hunts
+from lib import geo_engine
 
 logging.config.dictConfig(ail_logger.get_config(name='ail'))
 
@@ -174,6 +175,40 @@ class AbstractObject(ABC):
         return Tag.is_tags_safe(tags)
 
     ## -Tags- ##
+
+    ## GEO ##
+
+    def add_geo(self, lon, lat, probability=None, geo_id=None):
+        """Add one GEO observation point to this object."""
+        return geo_engine.add_geo_to_object(
+            self.get_global_id(),
+            self.get_type(),
+            lon,
+            lat,
+            probability=probability,
+            geo_id=geo_id
+        )
+
+    def remove_geo(self, geo_id):
+        """Remove one GEO observation point from this object."""
+        return geo_engine.remove_geo_from_object(
+            self.get_global_id(),
+            self.get_type(),
+            geo_id
+        )
+
+    def is_geo(self):
+        """Return whether this object has at least one GEO observation point."""
+        return geo_engine.object_has_geo(self.get_global_id())
+
+    def delete_geos(self):
+        """Delete all GEO observation points from this object."""
+        return geo_engine.delete_all_geo_from_object(
+            self.get_global_id(),
+            self.get_type()
+        )
+
+    ## -GEO- ##
 
     @abstractmethod
     def get_content(self):

--- a/tests/test_geo_engine.py
+++ b/tests/test_geo_engine.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+os.environ.setdefault('AIL_BIN', os.path.join(os.getcwd(), 'bin'))
+os.environ.setdefault('AIL_HOME', os.getcwd())
+
+sys.path.append(os.environ['AIL_BIN'])
+
+from lib import geo_engine
+from lib.objects.abstract_object import AbstractObject
+
+
+class FakeGeoRedis:
+
+    def __init__(self):
+        self.hashes = {}
+        self.geo_zsets = {}
+
+    def hset(self, key, field, value):
+        if key not in self.hashes:
+            self.hashes[key] = {}
+        is_new = field not in self.hashes[key]
+        self.hashes[key][field] = str(value)
+        return 1 if is_new else 0
+
+    def hget(self, key, field):
+        return self.hashes.get(key, {}).get(field)
+
+    def zcard(self, key):
+        return len(self.geo_zsets.get(key, {}))
+
+    def zrange(self, key, start, end):
+        members = list(self.geo_zsets.get(key, {}).keys())
+        if end == -1:
+            return members[start:]
+        return members[start:end + 1]
+
+    def zrem(self, key, *members):
+        if key not in self.geo_zsets:
+            return 0
+        removed = 0
+        for member in members:
+            if member in self.geo_zsets[key]:
+                del self.geo_zsets[key][member]
+                removed += 1
+        return removed
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            if key in self.hashes:
+                del self.hashes[key]
+                removed += 1
+            if key in self.geo_zsets:
+                del self.geo_zsets[key]
+                removed += 1
+        return removed
+
+    def geoadd(self, key, values):
+        lon, lat, member = values
+        if key not in self.geo_zsets:
+            self.geo_zsets[key] = {}
+        self.geo_zsets[key][member] = (str(lon), str(lat))
+        return 1
+
+    def geopos(self, key, *members):
+        res = []
+        for member in members:
+            res.append(self.geo_zsets.get(key, {}).get(member))
+        return res
+
+
+class DummyObject(AbstractObject):
+    def get_content(self):
+        return None
+
+
+class TestGeoEngine(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_geo = FakeGeoRedis()
+        geo_engine.r_geo = self.fake_geo
+
+    def test_add_one_geo(self):
+        with patch('lib.geo_engine.ail_core.generate_uuid', return_value='11111111-1111-4111-8111-111111111111'):
+            geo_id = geo_engine.add_geo_to_object('item::id-1', 'item', 1.0, 2.0, probability=0.8)
+
+        self.assertEqual(geo_id, '11111111111141118111111111111111')
+        self.assertEqual(self.fake_geo.hget(f'g:{geo_id}', 'o'), 'item::id-1')
+        self.assertEqual(self.fake_geo.hget(f'g:{geo_id}', 'p'), '0.8')
+        self.assertEqual(self.fake_geo.zcard('o:item::id-1'), 1)
+        self.assertEqual(self.fake_geo.zcard('objs:item'), 1)
+
+    def test_add_two_geos_same_object(self):
+        geo_engine.add_geo_to_object('item::id-2', 'item', 3.0, 4.0, geo_id='geo-A')
+        geo_engine.add_geo_to_object('item::id-2', 'item', 5.0, 6.0, geo_id='geo-B')
+
+        self.assertTrue(geo_engine.object_has_geo('item::id-2'))
+        self.assertEqual(self.fake_geo.zcard('o:item::id-2'), 2)
+        self.assertEqual(geo_engine.get_geo_position('item::id-2', 'geo-A'), [('3.0', '4.0')])
+
+    def test_same_coordinates_different_objects(self):
+        geo_engine.add_geo_to_object('item::id-3', 'item', 7.0, 8.0, geo_id='geo-C')
+        geo_engine.add_geo_to_object('domain::id-4', 'domain', 7.0, 8.0, geo_id='geo-D')
+
+        self.assertEqual(self.fake_geo.zcard('o:item::id-3'), 1)
+        self.assertEqual(self.fake_geo.zcard('o:domain::id-4'), 1)
+        self.assertNotEqual(geo_engine.get_geo_object_gid('geo-C'), geo_engine.get_geo_object_gid('geo-D'))
+
+    def test_remove_one_geo(self):
+        geo_engine.add_geo_to_object('item::id-5', 'item', 1.2, 3.4, geo_id='geo-E')
+        removed = geo_engine.remove_geo_from_object('item::id-5', 'item', 'geo-E')
+
+        self.assertTrue(removed)
+        self.assertFalse(geo_engine.object_has_geo('item::id-5'))
+        self.assertIsNone(geo_engine.get_geo_object_gid('geo-E'))
+
+    def test_object_with_no_geo(self):
+        self.assertFalse(geo_engine.object_has_geo('item::missing'))
+        self.assertEqual(geo_engine.delete_all_geo_from_object('item::missing', 'item'), 0)
+
+    def test_delete_all_geos(self):
+        geo_engine.add_geo_to_object('item::id-6', 'item', 9.0, 10.0, geo_id='geo-F')
+        geo_engine.add_geo_to_object('item::id-6', 'item', 11.0, 12.0, geo_id='geo-G')
+
+        removed = geo_engine.delete_all_geo_from_object('item::id-6', 'item')
+        self.assertEqual(removed, 2)
+        self.assertFalse(geo_engine.object_has_geo('item::id-6'))
+        self.assertIsNone(geo_engine.get_geo_object_gid('geo-F'))
+        self.assertIsNone(geo_engine.get_geo_object_gid('geo-G'))
+
+    def test_get_all_geo_positions(self):
+        geo_engine.add_geo_to_object('item::id-7', 'item', 2.1, 3.2, geo_id='geo-I')
+        geo_engine.add_geo_to_object('item::id-7', 'item', 4.3, 5.4, geo_id='geo-J')
+
+        geos = geo_engine.get_all_geo_positions('item::id-7')
+        self.assertEqual(len(geos), 2)
+        self.assertEqual(geos[0]['geo_id'], 'geo-I')
+        self.assertEqual(geos[0]['position'], ('2.1', '3.2'))
+
+    def test_get_object_nb_geos(self):
+        geo_engine.add_geo_to_object('item::id-8', 'item', 1.0, 1.0, geo_id='geo-K')
+        geo_engine.add_geo_to_object('item::id-8', 'item', 2.0, 2.0, geo_id='geo-L')
+
+        self.assertEqual(geo_engine.get_object_nb_geos('item::id-8'), 2)
+
+    def test_yield_objects_type_geos(self):
+        geo_engine.add_geo_to_object('item::id-9', 'item', 9.1, 9.2, probability=0.7, geo_id='geo-M')
+        geo_engine.add_geo_to_object('item::id-10', 'item', 10.1, 10.2, geo_id='geo-N')
+
+        geos = list(geo_engine.yield_objects_type_geos('item'))
+        geo_ids = {geo['geo_id'] for geo in geos}
+        self.assertIn('geo-M', geo_ids)
+        self.assertIn('geo-N', geo_ids)
+        first = [geo for geo in geos if geo['geo_id'] == 'geo-M'][0]
+        self.assertEqual(first['obj_gid'], 'item::id-9')
+        self.assertEqual(first['position'], ('9.1', '9.2'))
+        self.assertEqual(first['probability'], '0.7')
+
+    def test_abstract_object_geo_methods(self):
+        obj = DummyObject('item', 'obj-1')
+        with patch('lib.objects.abstract_object.geo_engine.add_geo_to_object', return_value='geo-H') as m_add, \
+             patch('lib.objects.abstract_object.geo_engine.remove_geo_from_object', return_value=True) as m_remove, \
+             patch('lib.objects.abstract_object.geo_engine.object_has_geo', return_value=True) as m_has, \
+             patch('lib.objects.abstract_object.geo_engine.delete_all_geo_from_object', return_value=1) as m_delete:
+
+            self.assertEqual(obj.add_geo(1.0, 2.0, probability=0.5), 'geo-H')
+            self.assertTrue(obj.remove_geo('geo-H'))
+            self.assertTrue(obj.is_geo())
+            self.assertEqual(obj.delete_geos(), 1)
+
+            m_add.assert_called_once_with('item::obj-1', 'item', 1.0, 2.0, probability=0.5, geo_id=None)
+            m_remove.assert_called_once_with('item::obj-1', 'item', 'geo-H')
+            m_has.assert_called_once_with('item::obj-1')
+            m_delete.assert_called_once_with('item::obj-1', 'item')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a centralized GEO helper module to manage geographic observation points for objects and index them in the Kvrocks GEO DB.
- Expose simple object-level APIs to add/remove/query GEO data from `AbstractObject` so higher-level code can manage GEO points directly on objects.

### Description

- Add `bin/lib/geo_engine.py` which implements GEO utilities including `create_geo_id`, `add_geo_to_object`, `remove_geo_from_object`, `object_has_geo`, `delete_all_geo_from_object`, `get_geo_probability`, `get_geo_object_gid`, `get_geo_position`, `get_all_geo_positions`, `get_object_nb_geos`, and `yield_objects_type_geos` using a `Kvrocks_GEO` connection from `ConfigLoader` and `ail_core.generate_uuid` for ids.
- Integrate GEO support into `AbstractObject` by importing `geo_engine` and adding instance methods `add_geo`, `remove_geo`, `is_geo`, and `delete_geos` that delegate to the new `geo_engine` functions and use the object's global id and type.
- Add unit tests at `tests/test_geo_engine.py` which provide a `FakeGeoRedis` mock, exercise the geo engine functions and the `AbstractObject` methods, and validate expected behaviors for adding, removing, querying, and deleting GEO entries.

### Testing

- Added `tests/test_geo_engine.py` unit test suite which mocks the Redis/Kvrocks interactions with `FakeGeoRedis` and patches `ail_core.generate_uuid` where needed to validate id generation and storage semantics.
- Ran the tests with `python -m unittest discover -s tests` and the new geo engine tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf9950ffc832d82848d0e741cf016)