### PR TITLE
Introduce devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu24.04",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	"onCreateCommand": "git submodule update --init --recursive",
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "./installing_deps.sh",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+}

--- a/.github/workflows/ail_framework_test.yml
+++ b/.github/workflows/ail_framework_test.yml
@@ -15,6 +15,8 @@ jobs:
   # This workflow contains a single job called "build"
   ail_test:
     # The type of runner that the job will run on
+    # Specifying -latest as a feature: when the version bumps, if it breaks the CI,
+    # it'll be a nudge to fix what broke & add the new Ubuntu version supported
     runs-on: ubuntu-latest
 
     # TODO: Matrix strategy for Python versions is defined but never used.

--- a/README.md
+++ b/README.md
@@ -209,9 +209,22 @@ Instead of treating those sources separately, AIL helps turn them into searchabl
 
 ![ui_submit](./doc/screenshots/ui_submit.png?raw=true "UI importer")
 
-## Installation
+## Using AIL
 
-To install the AIL framework:
+### Requirements
+
+- Python 3.8+
+- Ubuntu 24.04
+
+[How to size the hardware requirements for AIL?](https://ail-project.org/faq.html)
+
+### Installation
+
+Two options:
+1. For a local testing, you can use the [provided devcontainer](./.devcontainer/devcontainer.json). It'll execute the steps below within a container, they take few minutes to complete.
+2. Install locally
+
+To install AIL locally
 
 ```bash
 # Clone the repository
@@ -219,40 +232,22 @@ git clone https://github.com/ail-project/ail-framework.git
 cd ail-framework
 git submodule update --init --recursive
 
-# Install dependencies on Debian/Ubuntu-based distributions
+# Install dependencies for Ubuntu
 ./installing_deps.sh
+```
 
-# Start AIL
+To start AIL:
+
+```
 cd bin
 ./LAUNCH.sh -l
 ```
 
-The default [installing_deps.sh](./installing_deps.sh) script targets Debian and Ubuntu based distributions.
+The web interface is available by default at [https://localhost:7000/](https://localhost:7000/).
 
-### Requirements
+The default credentials can be found in `./DEFAULT_PASSWORD`. That file is removed once the password for the user `admin@admin.test` is changed.
 
-- Python 3.8+
-
-[How to size the hardware requirements for AIL?](https://ail-project.org/faq.html)
-
-### Installation notes
-
-
-Some optional components require additional configuration, including the **Lacus crawler**, the **Meilisearch search indexer**, and the **translation**. See the [HOWTO](https://github.com/ail-project/ail-framework/blob/master/HOWTO.md#crawler) for detailed setup instructions.
-## Starting AIL
-
-```bash
-cd bin
-./LAUNCH.sh -l
-```
-
-The web interface is available at:
-
-```text
-https://localhost:7000/
-```
-
-The default credentials are stored in the `DEFAULT_PASSWORD` file and the file is removed once the password is changed.
+Optional components require additional configuration: the **Lacus crawler**, the **Meilisearch search indexer**, and the **translation**. See the [HOWTO](https://github.com/ail-project/ail-framework/blob/master/HOWTO.md) for detailed setup instructions.
 
 ## Documentation
 

--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -8,39 +8,37 @@ set -e
 
 sudo apt-get update
 
-sudo apt-get install python3-pip virtualenv python3-dev python3-tk libfreetype6-dev \
-    screen g++ unzip libsnappy-dev cmake -qq
-
-sudo apt-get install automake libtool make gcc pkg-config -qq
+packages="python3-pip virtualenv python3-dev python3-tk libfreetype6-dev screen g++ unzip libsnappy-dev cmake automake libtool make gcc pkg-config"
 
 #Needed for downloading jemalloc
-sudo apt-get install wget -qq
+packages="${packages} wget"
 
 #Needed for bloom filters
-sudo apt-get install libssl-dev libfreetype6-dev python3-numpy -qq
+packages="${packages} libssl-dev libfreetype6-dev python3-numpy"
 
 # pycld3
-sudo apt-get install protobuf-compiler libprotobuf-dev -qq
+packages="${packages} protobuf-compiler libprotobuf-dev"
 
 # qrcode
-sudo apt-get install python3-opencv -y
-sudo apt-get install libzbar0 -y
+packages="${packages} python3-opencv libzbar0"
 
 # DNS deps
-sudo apt-get install libadns1 libadns1-dev -qq
+packages="${packages} libadns1 libadns1-dev"
 
 #Needed for redis-lvlDB
-sudo apt-get install libev-dev libgmp-dev -qq # TODO NEED REVIEW
+packages="${packages} libev-dev libgmp-dev" # TODO NEED REVIEW
 
 #Need for generate-data-flow graph
-sudo apt-get install graphviz -qq
+packages="${packages} graphviz"
 
 # ssdeep
-sudo apt-get install libfuzzy-dev -qq
-sudo apt-get install build-essential libffi-dev autoconf -qq
+packages="${packages} libfuzzy-dev build-essential libffi-dev autoconf"
 
 # sflock, gz requirement
-sudo apt-get install p7zip-full -qq # TODO REMOVE ME
+packages="${packages} p7zip-full" # TODO REMOVE ME
+
+# resolve needed packages & install all at once while keeping history of why some packages are needed.
+sudo apt-get install --assume-yes ${packages}
 
 # SUBMODULES #
 git submodule update --init --recursive
@@ -49,7 +47,7 @@ git submodule update --init --recursive
 test ! -d redis/ && git clone https://github.com/redis/redis.git
 pushd redis/
 git checkout 5.0
-make
+make -j
 popd
 
 # tlsh
@@ -67,7 +65,7 @@ test ! -d pgpdump && git clone https://github.com/kazu-yamamoto/pgpdump.git
 pushd pgpdump/
 autoreconf -fiW all
 ./configure
-make
+make -j
 sudo make install
 popd
 
@@ -79,7 +77,7 @@ unzip yara_temp/yara.zip -d yara_temp/
 pushd yara_temp/yara-${YARA_VERSION}
 ./bootstrap.sh
 ./configure
-make
+make -j
 sudo make install
 make check
 popd


### PR DESCRIPTION
The goal is to enable people that do not run an Ubuntu machine to easily run & contribute to the project.

A big devcontainer's aim I had was to change as little as possible the current dev net the team is using & to avoid duplication (e.g: apt-get install dependencies in both the [installing_deps.sh](https://github.com/ail-project/ail-framework/blob/master/installing_deps.sh) & devcontainer's config or Dockerfile

`-j` added to the `make` steps to compile using all available cpu cores