### PR TITLE
Make correlation tooltips responsive and support multi-image blur control

### DIFF
--- a/var/www/templates/correlation/show_correlation.html
+++ b/var/www/templates/correlation/show_correlation.html
@@ -101,13 +101,14 @@
 		}
 
         .pivotik-tooltip-card {
-            width: min(44rem, 92vw);
-            max-width: 44rem;
+            width: 100%;
+            max-width: 100%;
             background-color: #1f1f1f;
             color: #f8f9fa;
             border: 1px solid #3a3a3a;
             border-radius: 0.5rem;
             box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.35);
+            box-sizing: border-box;
         }
 
         .pivotik-tooltip-card .card-header {
@@ -120,31 +121,37 @@
         .pivotik-tooltip-details {
             display: flex;
             flex-direction: column;
-            gap: 0.35rem;
-            margin-top: 0.25rem;
+            gap: 0.2rem;
         }
 
         .pivotik-tooltip-row {
             display: flex;
-            flex-direction: column;
+            flex-direction: row;
+            align-items: flex-start;
+            gap: 0.45rem;
             background: rgba(255, 255, 255, 0.04);
             border-radius: 0.35rem;
-            padding: 0.35rem 0.5rem;
+            padding: 0.25rem 0.45rem;
         }
 
         .pivotik-tooltip-label {
             color: #b9c0c7;
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             text-transform: uppercase;
             letter-spacing: 0.03em;
+            min-width: 6.5rem;
+            flex: 0 0 6.5rem;
+            line-height: 1.3;
         }
 
         .pivotik-tooltip-value {
             color: #f8f9fa;
             word-break: break-word;
-            white-space: pre-wrap;
-            line-height: 1.35;
-            font-size: 0.86rem;
+            overflow-wrap: anywhere;
+            white-space: normal;
+            line-height: 1.25;
+            font-size: 0.82rem;
+            flex: 1 1 auto;
         }
 
         .pivotik-tooltip-tags {
@@ -167,12 +174,14 @@
 
         .pvt-tooltip {
             white-space: normal !important;
+            max-width: min(92vw, 44rem) !important;
         }
 
         .pvt-tooltip .pvt-tooltip-container {
-            max-height: none !important;
-            overflow: visible !important;
+            max-height: min(75vh, 38rem) !important;
+            overflow: auto !important;
             max-width: min(92vw, 44rem) !important;
+            width: min(92vw, 44rem) !important;
             min-height: 0 !important;
             resize: none !important;
         }
@@ -614,11 +623,13 @@ $(document).ready(function(){
 const blur_slider_correlation = $('#blur-slider-correlation');
 blur_slider_correlation.on('input change', blur_tooltip);
 function blur_tooltip(){
-    var image = $('#tooltip_screenshot_correlation')[0];
-    if (image) {
-        var blurValue = $('#blur-slider-correlation').val();
+    var images = document.getElementsByClassName('correlation-tooltip-image');
+    if (images.length) {
+        var blurValue = blur_slider_correlation.val();
         blurValue = 15 - blurValue;
-        image.style.filter = "blur(" + blurValue + "px)";
+        for (var i = 0; i < images.length; i++) {
+            images[i].style.filter = "blur(" + blurValue + "px)";
+        }
     }
 }
 
@@ -750,7 +761,7 @@ function build_tooltip_html(title, data) {
             } else {
                 desc = desc + "<img src={{ url_for('objects_image.image', filename="") }}";
             }
-            desc = desc + data.img + ' class="img-thumbnail blured" id="tooltip_screenshot_correlation" style="max-height: 14rem;"/>';
+            desc = desc + data.img + ' class="img-thumbnail blured correlation-tooltip-image" style="max-height: 14rem;"/>';
         } else {
             desc = desc + '<span class="my-2 fa-stack fa-4x"><i class="fas fa-stack-1x fa-image"></i><i class="fas fa-stack-2x fa-ban" style="color:Red"></i></span>';
         }


### PR DESCRIPTION
### Motivation

- Improve tooltip layout and responsiveness so tooltip content doesn't overflow or get clipped on small screens.
- Allow the blur slider to apply to multiple tooltip images instead of a single hard-coded element.

### Description

- Updated tooltip styling to use full-width constraints and `box-sizing`, tightened paddings and font sizes, and converted tooltip rows to a row-based flex layout with fixed label width and flexible value area (`.pivotik-tooltip-card`, `.pivotik-tooltip-row`, `.pivotik-tooltip-label`, `.pivotik-tooltip-value`).
- Restricted tooltip container size and enabled scrolling by setting `max-height` and `overflow: auto` for `.pvt-tooltip .pvt-tooltip-container` and capped `.pvt-tooltip` max-width to `min(92vw, 44rem)`.
- Replaced the single image `id="tooltip_screenshot_correlation"` with a class `correlation-tooltip-image` in generated tooltip HTML so multiple images can be present and targeted uniformly.
- Updated the blur slider handler to select all `.correlation-tooltip-image` elements and apply the computed blur to each image; also switched to the cached jQuery slider reference `blur_slider_correlation`.

### Testing

- Ran the existing automated backend test suite with `pytest` and all tests passed.
- Ran the frontend/CSS adjustments through the project's CI linters and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09df4ef4c832dbc300cacc593766b)