### PR TITLE
Make correlation tooltips responsive and support multi-image blur control

### DIFF
--- a/var/www/templates/correlation/show_correlation.html
+++ b/var/www/templates/correlation/show_correlation.html
@@ -101,13 +101,14 @@
 		}
 
         .pivotik-tooltip-card {
-            width: min(44rem, 92vw);
-            max-width: 44rem;
+            width: auto;
+            max-width: min(92vw, 44rem);
             background-color: #1f1f1f;
             color: #f8f9fa;
             border: 1px solid #3a3a3a;
             border-radius: 0.5rem;
             box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.35);
+            box-sizing: border-box;
         }
 
         .pivotik-tooltip-card .card-header {
@@ -120,31 +121,37 @@
         .pivotik-tooltip-details {
             display: flex;
             flex-direction: column;
-            gap: 0.35rem;
-            margin-top: 0.25rem;
+            gap: 0.2rem;
         }
 
         .pivotik-tooltip-row {
             display: flex;
-            flex-direction: column;
+            flex-direction: row;
+            align-items: flex-start;
+            gap: 0.45rem;
             background: rgba(255, 255, 255, 0.04);
             border-radius: 0.35rem;
-            padding: 0.35rem 0.5rem;
+            padding: 0.25rem 0.45rem;
         }
 
         .pivotik-tooltip-label {
             color: #b9c0c7;
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             text-transform: uppercase;
             letter-spacing: 0.03em;
+            flex: 0 0 auto;
+            line-height: 1.3;
+            white-space: nowrap;
         }
 
         .pivotik-tooltip-value {
             color: #f8f9fa;
             word-break: break-word;
-            white-space: pre-wrap;
-            line-height: 1.35;
-            font-size: 0.86rem;
+            overflow-wrap: anywhere;
+            white-space: normal;
+            line-height: 1.25;
+            font-size: 0.82rem;
+            flex: 1 1 auto;
         }
 
         .pivotik-tooltip-tags {
@@ -167,12 +174,15 @@
 
         .pvt-tooltip {
             white-space: normal !important;
+            max-width: min(92vw, 44rem) !important;
         }
 
         .pvt-tooltip .pvt-tooltip-container {
-            max-height: none !important;
-            overflow: visible !important;
+            max-height: min(75vh, 38rem) !important;
+            overflow: auto !important;
             max-width: min(92vw, 44rem) !important;
+            width: max-content !important;
+            min-width: 14rem !important;
             min-height: 0 !important;
             resize: none !important;
         }
@@ -614,11 +624,13 @@ $(document).ready(function(){
 const blur_slider_correlation = $('#blur-slider-correlation');
 blur_slider_correlation.on('input change', blur_tooltip);
 function blur_tooltip(){
-    var image = $('#tooltip_screenshot_correlation')[0];
-    if (image) {
-        var blurValue = $('#blur-slider-correlation').val();
+    var images = document.getElementsByClassName('correlation-tooltip-image');
+    if (images.length) {
+        var blurValue = blur_slider_correlation.val();
         blurValue = 15 - blurValue;
-        image.style.filter = "blur(" + blurValue + "px)";
+        for (var i = 0; i < images.length; i++) {
+            images[i].style.filter = "blur(" + blurValue + "px)";
+        }
     }
 }
 
@@ -750,7 +762,7 @@ function build_tooltip_html(title, data) {
             } else {
                 desc = desc + "<img src={{ url_for('objects_image.image', filename="") }}";
             }
-            desc = desc + data.img + ' class="img-thumbnail blured" id="tooltip_screenshot_correlation" style="max-height: 14rem;"/>';
+            desc = desc + data.img + ' class="img-thumbnail blured correlation-tooltip-image" style="max-height: 14rem;"/>';
         } else {
             desc = desc + '<span class="my-2 fa-stack fa-4x"><i class="fas fa-stack-1x fa-image"></i><i class="fas fa-stack-2x fa-ban" style="color:Red"></i></span>';
         }


### PR DESCRIPTION
### Motivation
- Improve tooltip layout and responsiveness to avoid overflow and wrapping issues on narrow viewports.
- Ensure the blur slider affects all images inside a tooltip instead of only a single hard-coded element.
- Provide consistent sizing and scrolling behavior for large tooltip content.

### Description
- Adjusted `.pivotik-tooltip-card` sizing and added `box-sizing: border-box` to allow more flexible width handling and proper max-width behavior.
- Reworked tooltip internals by switching `.pivotik-tooltip-row` to a row flex layout and adding explicit `flex` rules on `.pivotik-tooltip-label` and `.pivotik-tooltip-value` to stabilize label/value alignment and wrapping, plus tuned gaps, paddings, font-sizes, and line-heights.
- Constrained `.pvt-tooltip` and `.pvt-tooltip .pvt-tooltip-container` with `max-width`, `max-height`, `min-width`, and enabled `overflow: auto` to prevent oversized tooltips from overflowing the viewport and to make them scrollable.
- Replaced the single-element blur logic with a multi-image approach by selecting elements with the `correlation-tooltip-image` class and applying the blur in a loop, and updated `build_tooltip_html` to add that class to tooltip images (and removed the fixed `id`).

### Testing
- Ran the project's automated backend test suite with `pytest` and all tests passed. 
- Ran the frontend automated checks with `npm test` (lint/tests) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09df4ef4c832dbc300cacc593766b)