### PR TITLE
fix: apply image blur slider variable to all related templates

### DIFF
--- a/var/www/templates/chats_explorer/basic_card_chat.html
+++ b/var/www/templates/chats_explorer/basic_card_chat.html
@@ -1,6 +1,6 @@
 <style>
     .object_image {
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/chats_explorer/basic_card_image.html
+++ b/var/www/templates/chats_explorer/basic_card_image.html
@@ -1,6 +1,6 @@
 <style>
     .object_image {
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/chats_explorer/block_message.html
+++ b/var/www/templates/chats_explorer/block_message.html
@@ -16,7 +16,7 @@
         background: #eee;
     }
     .object_image {
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/chats_explorer/card_image.html
+++ b/var/www/templates/chats_explorer/card_image.html
@@ -9,7 +9,7 @@
 
 <style>
     .object_image {
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/chats_explorer/chat_viewer.html
+++ b/var/www/templates/chats_explorer/chat_viewer.html
@@ -41,7 +41,7 @@
         }
         .message_image {
             max-width: 50%;
-            filter: blur(5px);
+            filter: blur(var(--object-image-blur, 5px));
         }
 	</style>
 

--- a/var/www/templates/correlation/show_relationship.html
+++ b/var/www/templates/correlation/show_relationship.html
@@ -73,7 +73,7 @@
         }
 
         .blured {
-            filter: blur(5px);
+            filter: blur(var(--object-image-blur, 5px));
         }
 
 		.graph_panel {

--- a/var/www/templates/domains/card_img_domain.html
+++ b/var/www/templates/domains/card_img_domain.html
@@ -2,7 +2,7 @@
     .object_image {
         max-height: 400px;
         max-width: 100%;
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/objects/author/card_author.html
+++ b/var/www/templates/objects/author/card_author.html
@@ -9,7 +9,7 @@
 
 <style>
     .object_image {
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/objects/barcode/card_barcode.html
+++ b/var/www/templates/objects/barcode/card_barcode.html
@@ -9,7 +9,7 @@
 
 <style>
     .object_image {
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/objects/block_obj_css.html
+++ b/var/www/templates/objects/block_obj_css.html
@@ -67,7 +67,7 @@ block-obj {
 }
 
 .object_image {
-    filter: blur(5px);
+    filter: blur(var(--object-image-blur, 5px));
 }
 
 .image-preview-wrap {

--- a/var/www/templates/objects/ocr/card_ocr.html
+++ b/var/www/templates/objects/ocr/card_ocr.html
@@ -9,7 +9,7 @@
 
 <style>
     .object_image {
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/objects/qrcode/card_qrcode.html
+++ b/var/www/templates/objects/qrcode/card_qrcode.html
@@ -9,7 +9,7 @@
 
 <style>
     .object_image {
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 

--- a/var/www/templates/objects/tooltip_ail_objects.html
+++ b/var/www/templates/objects/tooltip_ail_objects.html
@@ -99,7 +99,7 @@ function mouseover_tooltip_ail_obj(event, d, obj_gid, obj_label, additional_text
                     } else {
                         desc = desc + "<img src={{ url_for('objects_image.image', filename="") }}"
                     }
-                    desc = desc + data["img"] +" class=\"object_image\" id=\"tooltip_screenshot_correlation\" style=\"filter: blur(5px);max-width: 200px;\"/>";
+                    desc = desc + data["img"] +" class=\"object_image\" id=\"tooltip_screenshot_correlation\" style=\"filter: blur(var(--object-image-blur, 5px));max-width: 200px;\"/>";
                 } else {
                     desc = desc + "<span class=\"my-2 fa-stack fa-4x\"><i class=\"fas fa-stack-1x fa-image\"></i><i class=\"fas fa-stack-2x fa-ban\" style=\"color:Red\"></i></span>";
                 }

--- a/var/www/templates/search/search_description_images.html
+++ b/var/www/templates/search/search_description_images.html
@@ -22,7 +22,7 @@
     <style>
     .object_image {
         max-width: 50%;
-        filter: blur(5px);
+        filter: blur(var(--object-image-blur, 5px));
     }
 </style>
 


### PR DESCRIPTION
### Motivation
- The correlation graph tooltip fix introduced a CSS variable `--object-image-blur` to control image blur centrally, but many templates still used a hardcoded `blur(5px)` which prevented the `block_blur_img_slider.html` slider from affecting them.
- Propagate the variable-based blur so the slider and tooltip behave consistently across the UI.

### Description
- Replaced hardcoded `filter: blur(5px)` with `filter: blur(var(--object-image-blur, 5px))` in multiple templates so they respect the global `--object-image-blur` CSS variable (14 templates updated). 
- Updated the correlation/tooltip inline image to use `filter: blur(var(--object-image-blur, 5px))` for consistency with the slider behavior.
- Ensured `block_blur_img_slider.html` sets the `--object-image-blur` variable so the slider controls blur across these views.

### Testing
- Ran a targeted search with `rg -n "filter:\s*blur\(5px\);" var/www/templates -S` and verified no active occurrences remain (only a commented instance in `FaviconDaterange.html`), and the search succeeded. 
- Applied changes via a small Python replacement script to update files and committed the result, producing a commit that modified 14 files (commit succeeded). 
- Confirmed repository status with `git status --short` and the working tree commit hash with `git rev-parse --short HEAD`, and generated a PR payload via the `make_pr` helper; all automated steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2317c3c70832db057d698a4f905dc)