### PR TITLE
Sync relationship-graph tooltip updates with correlation graph and preserve orientation

### DIFF
--- a/var/www/templates/correlation/show_relationship.html
+++ b/var/www/templates/correlation/show_relationship.html
@@ -484,7 +484,7 @@ $(document).ready(function(){
 
 const blur_slider_correlation = $('#blur-slider-correlation');
 function blur_tooltip(){
-    var image = $('#tooltip_screenshot_correlation')[0];
+    var image = $('.correlation-tooltip-image')[0];
     if (image) {
         var blurValue = $('#blur-slider-correlation').val();
         blurValue = 15 - blurValue;
@@ -543,9 +543,10 @@ const PivotickLib = window.Pivotick || {};
 const PivotickGraph = PivotickLib.Pivotick || PivotickLib.default || PivotickLib;
 const PivotickNode = PivotickLib.Node;
 const PivotickEdge = PivotickLib.Edge;
+var currentObject = null;
 
 function build_tooltip_html(title, data) {
-    const excludedKeys = ['tags', 'id', 'img', 'svg_icon', 'icon', 'link', 'type', 'tags_safe'];
+    const excludedKeys = ['tags', 'id', 'img', 'svg_icon', 'icon', 'link', 'type', 'tags_safe', 'is_tags_safe'];
     const prettifyKey = function(key) {
         return sanitize_text((key || '').replace(/_/g, ' '));
     };
@@ -563,7 +564,7 @@ function build_tooltip_html(title, data) {
             '</span><span class="pivotik-tooltip-value">' + sanitize_text(value) + '</span></div>';
     };
 
-    let desc = '<div class="card pivotik-tooltip-card"><div class="card-header py-2"><h6 class="mb-0">' + sanitize_text(title) + '</h6></div>';
+    let desc = '<div class="card pivotik-tooltip-card">';
     desc = desc + '<div class="card-body p-2">';
     desc = desc + '<div class="pivotik-tooltip-details">';
 
@@ -605,7 +606,7 @@ function build_tooltip_html(title, data) {
             } else {
                 desc = desc + "<img src={{ url_for('objects_image.image', filename="") }}";
             }
-            desc = desc + data.img + ' class="img-thumbnail blured" id="tooltip_screenshot_correlation" style="max-height: 14rem;"/>';
+            desc = desc + data.img + ' class="img-thumbnail correlation-tooltip-image object_image" style="max-height: 14rem;"/>';
         } else {
             desc = desc + '<span class="my-2 fa-stack fa-4x"><i class="fas fa-stack-1x fa-image"></i><i class="fas fa-stack-2x fa-ban" style="color:Red"></i></span>';
         }


### PR DESCRIPTION
### Motivation
- Bring the relationship graph tooltip behavior and markup in line with recent correlation-graph fixes so tooltips show the same fields and styling. 
- Keep the relationship graph oriented (directed edges) while applying tooltip changes. 
- Ensure the blur slider still works with the revised tooltip image markup and avoid implicit global variables used by keyboard/hover handlers.

### Description
- Added an explicit `currentObject` declaration to the relationship template to avoid implicit global usage in hover/keyboard behaviors. 
- Updated tooltip field filtering to exclude `is_tags_safe` so tooltip field rendering matches the correlation graph. 
- Removed the tooltip header block and aligned the tooltip image element to use the shared classes `correlation-tooltip-image object_image` to match correlation tooltip styling. 
- Updated `blur_tooltip()` to target the new `.correlation-tooltip-image` selector and preserved directed edges by keeping `PivotickEdge(..., true)` in the relationship graph creation.

### Testing
- Ran pattern checks with `rg` to verify `is_tags_safe`, `correlation-tooltip-image`, and directed edge construction exist in the modified file and they succeeded. 
- Reviewed the template diff with `git diff` to confirm only the intended changes were applied and the check succeeded. 
- Committed the change and verified the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23e57cb1c832db052f675048703cf)