### PR TITLE
Optimize module extractor regex safety and add extraction deadline handling

### DIFF
--- a/bin/lib/module_extractor.py
+++ b/bin/lib/module_extractor.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import sys
+import time
 
 import yara
 
@@ -38,6 +39,9 @@ r_cache = config_loader.get_redis_conn("Redis_Cache")
 config_loader = None
 
 r_key = regex_helper.generate_redis_cache_key('extractor')  # TODO MOVE IN extractor function
+
+EXTRACTION_MAX_SECONDS = 60
+REGEX_MAX_SECONDS = 5
 
 
 # SIGNAL ALARM
@@ -90,8 +94,30 @@ def merge_overlap(extracted):
     merged.append((curr_start, curr_end, curr_string_match, curr_obj_ref))
     return merged
 
-def get_correl_match(extract_type, obj, content):
+
+def deadline_exceeded(start_time, max_seconds=EXTRACTION_MAX_SECONDS):
+    return (time.monotonic() - start_time) >= max_seconds
+
+
+def _remaining_time(start_time, max_seconds=EXTRACTION_MAX_SECONDS):
+    return max(0.0, max_seconds - (time.monotonic() - start_time))
+
+
+def _regex_finditer_safe(regex, obj_gid, content, start_time, max_seconds=EXTRACTION_MAX_SECONDS,
+                         regex_max_seconds=REGEX_MAX_SECONDS):
+    if deadline_exceeded(start_time, max_seconds=max_seconds):
+        return []
+    remaining = _remaining_time(start_time, max_seconds=max_seconds)
+    if remaining <= 0:
+        return []
+    timeout = min(regex_max_seconds, max(0.1, remaining))
+    return regex_helper.regex_finditer(r_key, regex, obj_gid, content, max_time=timeout)
+
+
+def get_correl_match(extract_type, obj, content, start_time=None, max_seconds=EXTRACTION_MAX_SECONDS):
     extracted = []
+    if start_time and deadline_exceeded(start_time, max_seconds=max_seconds):
+        return extracted
     correl = correlations_engine.get_correlation_by_correl_type(obj.type, obj.get_subtype(r_str=True), obj.id, extract_type)
     to_extract = []
     map_subtype = {}
@@ -108,7 +134,8 @@ def get_correl_match(extract_type, obj, content):
             sha256_val = sha256(value.encode()).hexdigest()
         map_value_id[sha256_val] = value
     if to_extract:
-        objs = regex_helper.regex_finditer(r_key, '|'.join(to_extract), obj.get_global_id(), content, max_time=5)
+        objs = _regex_finditer_safe('|'.join(to_extract), obj.get_global_id(), content, start_time or time.monotonic(),
+                                    max_seconds=max_seconds)
         if extract_type == 'title' and objs:
             objs = [objs[0]]
         for ob in objs:
@@ -151,10 +178,16 @@ def convert_byte_offset_to_string(b_content, offset):
         return convert_byte_offset_to_string(b_content, offset - 1)
 
 
-def _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content, priority=None):
+def _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content, priority=None, start_time=None,
+                        max_seconds=EXTRACTION_MAX_SECONDS):
     extracted = []
     extracted_yara = []
+    regex_cache = {}
+    _start_time = start_time or time.monotonic()
     for tracker_uuid in trackers_uuids:
+        if deadline_exceeded(_start_time, max_seconds=max_seconds):
+            logger.warning('module_extractor: global extraction timeout reached while processing trackers')
+            break
         tracker = Tracker.Tracker(tracker_uuid)
         if not tracker.check_level(user_org, user_id):
             continue
@@ -163,13 +196,20 @@ def _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content, pri
         # print(tracker_type)
         tracked = tracker.get_tracked()
         if tracker_type == 'regex':  # TODO Improve word detection -> word delimiter
-            regex_match = regex_helper.regex_finditer(r_key, tracked, obj_gid, content, max_time=5)
+            if tracked in regex_cache:
+                regex_match = regex_cache[tracked]
+            else:
+                regex_match = _regex_finditer_safe(tracked, obj_gid, content, _start_time, max_seconds=max_seconds)
+                regex_cache[tracked] = regex_match
             for match in regex_match:
                 extracted.append([int(match[0]), int(match[1]), match[2], f'tracker:{tracker.uuid}'])
         elif tracker_type == 'yara':
+            if deadline_exceeded(_start_time, max_seconds=max_seconds):
+                break
             rule = tracker.get_rule()
+            timeout = min(REGEX_MAX_SECONDS, max(0.1, _remaining_time(_start_time, max_seconds=max_seconds)))
             rule.match(data=content.encode(), callback=_get_yara_match,
-                       which_callbacks=yara.CALLBACK_MATCHES, timeout=5)
+                       which_callbacks=yara.CALLBACK_MATCHES, timeout=timeout)
             yara_match = r_cache.smembers(f'extractor:yara:match:{r_key}')  # set in _get_yara_match callback
             r_cache.delete(f'extractor:yara:match:{r_key}')
             for match in yara_match:
@@ -183,8 +223,14 @@ def _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content, pri
             else:
                 words = [tracked]
             for word in words:
+                if deadline_exceeded(_start_time, max_seconds=max_seconds):
+                    break
                 regex = _get_word_regex(word)
-                regex_match = regex_helper.regex_finditer(r_key, regex, obj_gid, content, max_time=5)
+                if regex in regex_cache:
+                    regex_match = regex_cache[regex]
+                else:
+                    regex_match = _regex_finditer_safe(regex, obj_gid, content, _start_time, max_seconds=max_seconds)
+                    regex_cache[regex] = regex_match
                 # print(regex_match)
                 for match in regex_match:
                     extracted.append([int(match[0]), int(match[1]), match[2], f'tracker:{tracker.uuid}'])
@@ -194,15 +240,24 @@ def _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content, pri
                 escaped_domains = [regex_helper.regex_escape(typo_domain) for typo_domain in typo_domains]
                 escaped_domains.sort(key=len, reverse=True)
                 regex = _get_word_regex(f"(?:{'|'.join(escaped_domains)})")
-                regex_match = regex_helper.regex_finditer(r_key, regex, obj_gid, content, max_time=5)
+                if regex in regex_cache:
+                    regex_match = regex_cache[regex]
+                else:
+                    regex_match = _regex_finditer_safe(regex, obj_gid, content, _start_time, max_seconds=max_seconds)
+                    regex_cache[regex] = regex_match
                 for match in regex_match:
                     extracted.append([int(match[0]), int(match[1]), match[2], f'tracker:{tracker.uuid}'])
     return extracted, extracted_yara
 
 
-def _extract_retro_hunts(retro_hunts_uuids, user_org, content, priority=None):
+def _extract_retro_hunts(retro_hunts_uuids, user_org, content, priority=None, start_time=None,
+                         max_seconds=EXTRACTION_MAX_SECONDS):
     extracted_yara = []
+    _start_time = start_time or time.monotonic()
     for retro_uuid in retro_hunts_uuids:
+        if deadline_exceeded(_start_time, max_seconds=max_seconds):
+            logger.warning('module_extractor: global extraction timeout reached while processing retro hunts')
+            break
         retro_hunt = Tracker.RetroHunt(retro_uuid)
         if not retro_hunt.check_level(user_org):
             continue
@@ -213,8 +268,9 @@ def _extract_retro_hunts(retro_hunts_uuids, user_org, content, priority=None):
             retro_hunt.delete_objs()
             continue
 
+        timeout = min(REGEX_MAX_SECONDS, max(0.1, _remaining_time(_start_time, max_seconds=max_seconds)))
         rule.match(data=content.encode(), callback=_get_yara_match,
-                   which_callbacks=yara.CALLBACK_MATCHES, timeout=5)
+                   which_callbacks=yara.CALLBACK_MATCHES, timeout=timeout)
         yara_match = r_cache.smembers(f'extractor:yara:match:{r_key}')  # set in _get_yara_match callback
         r_cache.delete(f'extractor:yara:match:{r_key}')
         for match in yara_match:
@@ -224,16 +280,20 @@ def _extract_retro_hunts(retro_hunts_uuids, user_org, content, priority=None):
 
 
 # TODO TRACKER TYPE IN UI
-def get_tracker_match(user_org, user_id, obj, content, priority=None, match_uuid=None):
+def get_tracker_match(user_org, user_id, obj, content, priority=None, match_uuid=None, start_time=None,
+                      max_seconds=EXTRACTION_MAX_SECONDS):
+    start_time = start_time or time.monotonic()
     obj_gid = obj.get_global_id()
 
     if match_uuid:
         extracted = []
         if Tracker.is_tracker(match_uuid):
-            extracted, extracted_yara = _get_trackers_match([match_uuid], user_org, user_id, obj_gid, content)
+            extracted, extracted_yara = _get_trackers_match([match_uuid], user_org, user_id, obj_gid, content,
+                                                            start_time=start_time, max_seconds=max_seconds)
         # retro_hunt
         else:
-            extracted_yara = _extract_retro_hunts([match_uuid], user_org, content)
+            extracted_yara = _extract_retro_hunts([match_uuid], user_org, content, start_time=start_time,
+                                                  max_seconds=max_seconds)
 
     else:
         trackers_uuids = Tracker.get_obj_trackers(obj.type, obj.get_subtype(r_str=True), obj.id)
@@ -242,14 +302,21 @@ def get_tracker_match(user_org, user_id, obj, content, priority=None, match_uuid
         # check if priority is tracker or retro
         if priority:
             if priority in trackers_uuids:
-                extracted, extracted_yara = _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content, priority=priority)
-                extracted_retro_yara = _extract_retro_hunts(retro_hunts_uuids, user_org, content, priority=priority)
+                extracted, extracted_yara = _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content,
+                                                                priority=priority, start_time=start_time,
+                                                                max_seconds=max_seconds)
+                extracted_retro_yara = _extract_retro_hunts(retro_hunts_uuids, user_org, content, priority=priority,
+                                                            start_time=start_time, max_seconds=max_seconds)
             else:
-                extracted_retro_yara = _extract_retro_hunts(retro_hunts_uuids, user_org, content, priority=priority)
-                extracted, extracted_yara = _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content)
+                extracted_retro_yara = _extract_retro_hunts(retro_hunts_uuids, user_org, content, priority=priority,
+                                                            start_time=start_time, max_seconds=max_seconds)
+                extracted, extracted_yara = _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content,
+                                                                start_time=start_time, max_seconds=max_seconds)
         else:
-            extracted, extracted_yara = _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content)
-            extracted_retro_yara = _extract_retro_hunts(retro_hunts_uuids, user_org, content)
+            extracted, extracted_yara = _get_trackers_match(trackers_uuids, user_org, user_id, obj_gid, content,
+                                                            start_time=start_time, max_seconds=max_seconds)
+            extracted_retro_yara = _extract_retro_hunts(retro_hunts_uuids, user_org, content, start_time=start_time,
+                                                        max_seconds=max_seconds)
         if extracted_yara and extracted_retro_yara:
             extracted_yara[0:0] = extracted_retro_yara
         elif extracted_retro_yara:
@@ -272,6 +339,7 @@ def get_tracker_match(user_org, user_id, obj, content, priority=None, match_uuid
 # tag:iban
 # tracker:uuid
 def extract(user_id, obj_type, subtype, obj_id, content=None, priority=None, match_uuid=None):
+    start_time = time.monotonic()
     obj = ail_objects.get_object(obj_type, subtype, obj_id)
     if not obj.exists():
         return []
@@ -290,10 +358,18 @@ def extract(user_id, obj_type, subtype, obj_id, content=None, priority=None, mat
     try:
         if not content:
             content = obj.get_content()
-        extracted = get_tracker_match(user_org, user_id, obj, content, match_uuid=match_uuid)
+        extracted = []
+        if not deadline_exceeded(start_time):
+            extracted = get_tracker_match(user_org, user_id, obj, content, match_uuid=match_uuid,
+                                          start_time=start_time)
+        else:
+            logger.warning(f'module_extractor: global extraction timeout reached before tracker extraction for {obj_gid}')
         if not match_uuid:
             # print(item.get_tags())
             for tag in obj.get_tags():
+                if deadline_exceeded(start_time):
+                    logger.warning(f'module_extractor: global extraction timeout reached while processing modules for {obj_gid}')
+                    break
                 if MODULES.get(tag):
                     # print(tag)
                     module = MODULES.get(tag)
@@ -302,7 +378,10 @@ def extract(user_id, obj_type, subtype, obj_id, content=None, priority=None, mat
                         extracted = extracted + matches
 
             for obj_t in CORRELATION_TO_EXTRACT[obj.type]:
-                matches = get_correl_match(obj_t, obj, content)
+                if deadline_exceeded(start_time):
+                    logger.warning(f'module_extractor: global extraction timeout reached while processing correlations for {obj_gid}')
+                    break
+                matches = get_correl_match(obj_t, obj, content, start_time=start_time)
                 if matches:
                     extracted = extracted + matches
 
@@ -389,4 +468,3 @@ def get_extracted_by_match(extracted):
 #     # print(r)
 #
 #     print(time.time() - t0)
-

--- a/tests/test_module_extractor.py
+++ b/tests/test_module_extractor.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import types
+import unittest
+import importlib
+from unittest.mock import patch
+
+
+if 'AIL_BIN' not in os.environ:
+    os.environ['AIL_BIN'] = os.path.join(os.getcwd(), 'bin')
+sys.path.append(os.environ['AIL_BIN'])
+
+# Stub optional runtime dependencies so module_extractor can be imported in CI-lite envs.
+if 'yara' not in sys.modules:
+    sys.modules['yara'] = types.SimpleNamespace(CALLBACK_CONTINUE=0, CALLBACK_MATCHES=1, Error=Exception)
+
+stub_ail_users = types.ModuleType('lib.ail_users')
+stub_ail_users.get_user_org = lambda _user_id: 'org-1'
+sys.modules.setdefault('lib.ail_users', stub_ail_users)
+
+stub_objects_pkg = types.ModuleType('lib.objects')
+stub_ail_objects = types.SimpleNamespace(get_object=lambda *_args, **_kwargs: None)
+stub_titles = types.ModuleType('lib.objects.Titles')
+
+
+class _Title:
+    def __init__(self, value):
+        self._value = value
+
+    def get_content(self):
+        return self._value
+
+
+stub_titles.Title = _Title
+stub_objects_pkg.ail_objects = stub_ail_objects
+sys.modules.setdefault('lib.objects', stub_objects_pkg)
+sys.modules.setdefault('lib.objects.Titles', stub_titles)
+
+stub_exceptions = types.ModuleType('lib.exceptions')
+stub_exceptions.TimeoutException = RuntimeError
+sys.modules.setdefault('lib.exceptions', stub_exceptions)
+
+stub_corr = types.ModuleType('lib.correlations_engine')
+stub_corr.get_correlation_by_correl_type = lambda *_args, **_kwargs: []
+sys.modules.setdefault('lib.correlations_engine', stub_corr)
+
+stub_regex = types.ModuleType('lib.regex_helper')
+stub_regex.generate_redis_cache_key = lambda _name: 'extractor-test-key'
+stub_regex.regex_finditer = lambda *_args, **_kwargs: []
+stub_regex.regex_escape = lambda value: value
+sys.modules.setdefault('lib.regex_helper', stub_regex)
+
+
+class _FakeRedis:
+    def get(self, _key):
+        return None
+
+    def set(self, _key, _value):
+        return True
+
+    def expire(self, _key, _ttl):
+        return True
+
+    def smembers(self, _key):
+        return []
+
+    def delete(self, _key):
+        return True
+
+    def sadd(self, _key, _value):
+        return True
+
+
+class _FakeConfigLoader:
+    def get_redis_conn(self, _name):
+        return _FakeRedis()
+
+
+stub_cfg = types.ModuleType('lib.ConfigLoader')
+stub_cfg.ConfigLoader = _FakeConfigLoader
+sys.modules.setdefault('lib.ConfigLoader', stub_cfg)
+
+stub_tracker = types.ModuleType('lib.Tracker')
+stub_tracker.Tracker = lambda uuid: None
+stub_tracker.RetroHunt = lambda uuid: None
+stub_tracker.get_obj_trackers = lambda *_args, **_kwargs: []
+stub_tracker.get_obj_retro_hunts = lambda *_args, **_kwargs: []
+stub_tracker.get_tracked_typosquatting_domains = lambda *_args, **_kwargs: []
+stub_tracker.is_tracker = lambda _uuid: True
+sys.modules.setdefault('lib.Tracker', stub_tracker)
+
+
+def _stub_module_class(module_name, class_name):
+    mod = types.ModuleType(module_name)
+
+    class _M:
+        def __init__(self, queue=False):
+            pass
+
+        def extract(self, obj, content, tag):
+            return []
+
+    _M.__name__ = class_name
+    setattr(mod, class_name, _M)
+    return mod
+
+
+sys.modules.setdefault('modules.CreditCards', _stub_module_class('modules.CreditCards', 'CreditCards'))
+sys.modules.setdefault('modules.Iban', _stub_module_class('modules.Iban', 'Iban'))
+sys.modules.setdefault('modules.Mail', _stub_module_class('modules.Mail', 'Mail'))
+sys.modules.setdefault('modules.Onion', _stub_module_class('modules.Onion', 'Onion'))
+sys.modules.setdefault('modules.Phone', _stub_module_class('modules.Phone', 'Phone'))
+sys.modules.setdefault('modules.Tools', _stub_module_class('modules.Tools', 'Tools'))
+sys.modules['modules.Tools'].Tools.get_tools = lambda self: []
+
+module_extractor = importlib.import_module('lib.module_extractor')
+
+
+class FakeObj:
+    type = 'item'
+
+    def __init__(self):
+        self.id = 'obj-id'
+
+    def exists(self):
+        return True
+
+    def get_global_id(self):
+        return 'item::obj-id'
+
+    def get_subtype(self, r_str=False):
+        return ''
+
+    def get_tags(self):
+        return ['infoleak:automatic-detection="mail"']
+
+    def get_content(self):
+        return 'safe content'
+
+
+class FakeTracker:
+    def __init__(self, uuid):
+        self.uuid = uuid
+
+    def check_level(self, user_org, user_id):
+        return True
+
+    def get_type(self):
+        return 'regex'
+
+    def get_tracked(self):
+        return '(a+)+$'
+
+
+class FakeModule:
+    def extract(self, obj, content, tag):
+        return [[10, 14, 'mail', f'tag:{tag}']]
+
+
+class TestModuleExtractor(unittest.TestCase):
+
+    def test_regex_timeout_is_routed_through_regex_helper(self):
+        calls = []
+
+        def fake_regex_finditer(r_key, regex, item_id, content, max_time=30):
+            calls.append({'regex': regex, 'max_time': max_time, 'item_id': item_id})
+            return []
+
+        with patch.object(module_extractor.Tracker, 'Tracker', FakeTracker):
+            with patch.object(module_extractor.regex_helper, 'regex_finditer', side_effect=fake_regex_finditer):
+                module_extractor._get_trackers_match(
+                    ['tracker-1'], 'org-1', 'user-1', 'item::obj-id', 'aaaaaaaaaaaaaaaa!'
+                )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]['regex'], '(a+)+$')
+        self.assertLessEqual(calls[0]['max_time'], module_extractor.REGEX_MAX_SECONDS)
+
+    def test_global_timeout_returns_partial_results(self):
+        fake_obj = FakeObj()
+        call_count = {'count': 0}
+
+        def fake_deadline_exceeded(_start_time, max_seconds=60):
+            call_count['count'] += 1
+            # allow object lookup + tracker pass, then stop module/correlation loops
+            return call_count['count'] >= 3
+
+        with patch.object(module_extractor.ail_objects, 'get_object', return_value=fake_obj):
+            with patch.object(module_extractor, 'get_user_org', return_value='org-1'):
+                with patch.object(module_extractor, 'get_tracker_match', return_value=[[0, 4, 'seed', 'tracker:t1']]):
+                    with patch.object(module_extractor, 'deadline_exceeded', side_effect=fake_deadline_exceeded):
+                        result = module_extractor.extract('user-1', 'item', '', 'obj-id', content='safe content')
+
+        self.assertEqual(result, [(0, 4, 'seed', [('tracker:t1', 'seed')])])
+
+    def test_extract_regression_normal_flow(self):
+        fake_obj = FakeObj()
+        fake_module = FakeModule()
+        with patch.object(module_extractor.ail_objects, 'get_object', return_value=fake_obj):
+            with patch.object(module_extractor, 'get_user_org', return_value='org-1'):
+                with patch.object(module_extractor, 'get_tracker_match', return_value=[[0, 4, 'seed', 'tracker:t1']]):
+                    with patch.object(module_extractor, 'MODULES', {'infoleak:automatic-detection="mail"': fake_module}):
+                        with patch.object(module_extractor, 'CORRELATION_TO_EXTRACT', {'item': []}):
+                            result = module_extractor.extract('user-1', 'item', '', 'obj-id', content='safe content')
+
+        self.assertEqual(result, [
+            (0, 4, 'seed', [('tracker:t1', 'seed')]),
+            (10, 14, 'mail', [('tag:infoleak:automatic-detection="mail"', 'mail')]),
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Extraction can hang or be very slow due to unbounded user/module/tracker regexes and repeated scans, so the extractor needs per-regex timeout protection and a global deadline to return partial results instead of blocking.  

### Description
- Added global deadline helpers `deadline_exceeded` and `_remaining_time` and constants `EXTRACTION_MAX_SECONDS` (60s) and `REGEX_MAX_SECONDS` (5s) in `bin/lib/module_extractor.py`.  
- Introduced a safe regex wrapper `_regex_finditer_safe` that routes searches through `regex_helper.regex_finditer` using a bounded per-regex timeout computed from remaining global time.  
- Protected all regex-based extraction paths (correlations, trackers, word/set/typosquatting searches and YARA matching in trackers/retro-hunts) to use the safe wrapper or remaining-time-aware timeouts and to short-circuit when the global deadline is reached.  
- Added in-pass caching of identical regexes during tracker extraction to avoid repeated work and added short-circuit checks to break loops when the global deadline is hit, preserving the existing extracted output format and overlap-merge behavior.  
- Added a focused test module `tests/test_module_extractor.py` covering per-regex plumbing (ensuring calls go through `regex_helper` with bounded `max_time`), global deadline behavior (returns partial results), and a regression case for normal extraction flow.  

### Testing
- Run `pytest -q tests/test_module_extractor.py`; result: `3 passed` (all new tests succeeded).  
- The changes are limited to `bin/lib/module_extractor.py` and the new tests in `tests/test_module_extractor.py` and preserve public return formats so existing callers remain compatible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef64f7766c832d985980cec18f0015)