### PR TITLE
Show chat network/address on card and add 'Chats List' button

### DIFF
--- a/var/www/templates/chats_explorer/card_chat.html
+++ b/var/www/templates/chats_explorer/card_chat.html
@@ -60,6 +60,14 @@
                     </li>
                 {% endif %}
 
+                {% if meta['network'] or meta['address'] %}
+                    <li class="list-group-item py-0">
+                        <div class="my-2 text-secondary">
+                            {% if meta['network'] %}{{ meta['network'] }} {% endif %}{% if meta['address'] %}{{ meta['address'] }}{% endif %}
+                        </div>
+                    </li>
+                {% endif %}
+
 			<li class="list-group-item py-0">
 				<div class="my-2">
 					Tags:
@@ -98,6 +106,9 @@
                 <a href="{{ url_for('correlation.show_relationship')}}?type={{ meta['type'] }}&subtype={{ meta['subtype'] }}&id={{ meta['id'] }}">
                     <button class="btn btn-secondary"><i class="far fa-eye"></i> Relationships &nbsp;
                     </button>
+                </a>
+                <a href="{{ url_for('chats_explorer.chats_explorer_instance') }}?subtype={{ meta['subtype'] }}">
+                    <button class="btn btn-primary"><i class="fas fa-comments"></i> Chats List</button>
                 </a>
             {% endif %}
         </span>

--- a/var/www/templates/chats_explorer/chat_viewer.html
+++ b/var/www/templates/chats_explorer/chat_viewer.html
@@ -63,6 +63,7 @@
                     {% include 'chats_explorer/card_chat.html' %}
                 {% endwith %}
 
+
                 {% if chat['subchannels'] %}
                     <h4 class="mt-2">Sub-Channels:</h4>
                     <table id="tablesubchannels" class="table">


### PR DESCRIPTION
### Motivation
- Provide visibility of a chat's `network` and `address` on the chat detail card and add a quick navigation to the chats list from the object action area.

### Description
- Added a conditional block in `card_chat.html` to render `meta['network']` and `meta['address']` when present inside the list group. 
- Added a "Chats List" action button in `card_chat.html` that links to `chats_explorer.chats_explorer_instance?subtype={{ meta['subtype'] }}` and performed minor whitespace/formatting cleanup in `chat_viewer.html`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc5d05ba4832d83e4fc162a6b40db)